### PR TITLE
Adds a workflow to tag this repo on merge to main

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,22 @@
+name: Tag
+
+on:
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - '.gitignore'
+    - '.github/**'
+
+jobs:
+  tag:
+    name: Push Git Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tag and Create Release
+        uses: rymndhng/release-on-push-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          bump_version_scheme: patch
+          tag_prefix: ""


### PR DESCRIPTION
By default the semver is bumped by a patch version, this can be changed using a label added to the GitHub PR, valid labels are release:major and release:minor.