### PR TITLE
Add A records to dns/records module

### DIFF
--- a/dns/records/resources.tf
+++ b/dns/records/resources.tf
@@ -1,9 +1,9 @@
 # CNAME records
 
 locals {
-  cname_records = flatten([
+  a_records = flatten([
     for zone_name, zone_cfg in var.hosted_zone : [
-      for record_name, record_cfg in zone_cfg["cnames"] : {
+      for record_name, record_cfg in try(zone_cfg["a-records"], []) : {
         record_name         = record_name
         zone_name           = zone_name
         resource_group_name = zone_cfg["resource_group_name"]
@@ -12,6 +12,31 @@ locals {
       }
     ]
   ])
+
+  cname_records = flatten([
+    for zone_name, zone_cfg in var.hosted_zone : [
+      for record_name, record_cfg in try(zone_cfg["cnames"], []) : {
+        record_name         = record_name
+        zone_name           = zone_name
+        resource_group_name = zone_cfg["resource_group_name"]
+        target              = record_cfg["target"]
+        ttl                 = try(record_cfg["ttl"], 300)
+      }
+    ]
+  ])
+}
+
+resource "azurerm_dns_a_record" "a_records" {
+  for_each = {
+    for zone in local.a_records : "${zone.zone_name}.${zone.record_name}" => zone
+  }
+
+  name                = each.value.record_name
+  zone_name           = each.value.zone_name
+  resource_group_name = each.value.resource_group_name
+  ttl                 = each.value.ttl
+  records             = toset([each.value.target])
+
 }
 
 resource "azurerm_dns_cname_record" "cname_records" {


### PR DESCRIPTION
### Context

Using the dns/records module we need to be able to optionally create A records.

### Changes proposed in this PR

- Add optional A record resources to dns/records module
- Make the CName record resources optional

### Guidance to Review

Clone [add-platform-test-domains](https://github.com/DFE-Digital/teacher-services-cloud/tree/add-platform-test-domains) branch of teacher-services-cloud.  Run `make prod-domain domains-infra-plan`, it should report 1 DNS A record resources to add plus 1 change (tags on existing resource).