### PR TITLE
80 enhance frontdoor support

### DIFF
--- a/dns/records/resources.tf
+++ b/dns/records/resources.tf
@@ -1,5 +1,3 @@
-# CNAME records
-
 locals {
   a_records = flatten([
     for zone_name, zone_cfg in var.hosted_zone : [

--- a/domains/environment_domains/dns.tf
+++ b/domains/environment_domains/dns.tf
@@ -8,7 +8,7 @@ resource "azurerm_dns_txt_record" "main" {
   name                = join(".", ["_dnsauth", "${each.key}"])
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
-  ttl                 = 3600
+  ttl                 = 300
 
   record {
     value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
@@ -20,7 +20,7 @@ resource "azurerm_dns_txt_record" "apex" {
   name                = "_dnsauth"
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
-  ttl                 = 3600
+  ttl                 = 300
 
   record {
     value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
@@ -34,7 +34,7 @@ resource "azurerm_dns_cname_record" "main" {
   name                = each.key
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
-  ttl                 = 3600
+  ttl                 = 300
   record              = azurerm_cdn_frontdoor_endpoint.main[each.key].host_name
 }
 

--- a/domains/environment_domains/dns.tf
+++ b/domains/environment_domains/dns.tf
@@ -3,5 +3,47 @@ data "azurerm_dns_zone" "main" {
   resource_group_name = var.resource_group_name
 }
 
-# TODO: Create validation TXT record
-# TODO: Create domain ALIAS A record
+resource "azurerm_dns_txt_record" "main" {
+  for_each            = { for k in toset(var.domains) : k => k if k != "apex" }
+  name                = join(".", ["_dnsauth", "${each.key}"])
+  zone_name           = data.azurerm_dns_zone.main.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 3600
+
+  record {
+    value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
+  }
+}
+
+resource "azurerm_dns_txt_record" "apex" {
+  for_each            = { for k in toset(var.domains) : k => k if k == "apex" }
+  name                = "_dnsauth"
+  zone_name           = data.azurerm_dns_zone.main.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 3600
+
+  record {
+    value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
+  }
+}
+
+resource "azurerm_dns_cname_record" "main" {
+  depends_on = [azurerm_cdn_frontdoor_route.main]
+  for_each   = { for k in toset(var.domains) : k => k if k != "apex" }
+
+  name                = each.key
+  zone_name           = data.azurerm_dns_zone.main.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 3600
+  record              = azurerm_cdn_frontdoor_endpoint.main[each.key].host_name
+}
+
+resource "azurerm_dns_a_record" "main" {
+  depends_on          = [azurerm_cdn_frontdoor_route.main]
+  for_each            = { for k in toset(var.domains) : k => k if k == "apex" }
+  name                = "@"
+  zone_name           = data.azurerm_dns_zone.main.name
+  resource_group_name = var.resource_group_name
+  ttl                 = 300
+  target_resource_id  = azurerm_cdn_frontdoor_endpoint.main[each.key].id
+}

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -2,6 +2,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
   name                = var.front_door_name
   resource_group_name = var.resource_group_name
 }
+
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
   for_each = toset(var.domains)
 

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -42,52 +42,6 @@ resource "azurerm_cdn_frontdoor_custom_domain" "main" {
   }
 }
 
-resource "azurerm_dns_txt_record" "main" {
-  for_each = { for k in toset(var.domains) : k => k if k != "apex" }
-  name                = join(".", ["_dnsauth", "${each.key}"])
-  zone_name           = data.azurerm_dns_zone.main.name
-  resource_group_name = var.resource_group_name
-  ttl                 = 3600
-
-  record {
-    value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
-  }
-}
-
-resource "azurerm_dns_txt_record" "apex" {
-  for_each = { for k in toset(var.domains) : k => k if k == "apex" }
-  name                = "_dnsauth"
-  zone_name           = data.azurerm_dns_zone.main.name
-  resource_group_name = var.resource_group_name
-  ttl                 = 3600
-
-  record {
-    value = azurerm_cdn_frontdoor_custom_domain.main[each.key].validation_token
-  }
-}
-
-
-resource "azurerm_dns_cname_record" "main" {
-  depends_on = [azurerm_cdn_frontdoor_route.main]
-  for_each = { for k in toset(var.domains) : k => k if k != "apex" }
-
-  name                = each.key
-  zone_name           = data.azurerm_dns_zone.main.name
-  resource_group_name = var.resource_group_name
-  ttl                 = 3600
-  record              = azurerm_cdn_frontdoor_endpoint.main[each.key].host_name
-}
-
-resource "azurerm_dns_a_record" "main" {
-  depends_on          = [azurerm_cdn_frontdoor_route.main]
-  for_each = { for k in toset(var.domains) : k => k if k == "apex" }
-  name                = "@"
-  zone_name           = data.azurerm_dns_zone.main.name
-  resource_group_name = var.resource_group_name
-  ttl                 = 300
-  target_resource_id  = azurerm_cdn_frontdoor_endpoint.main[each.key].id
-}
-
 resource "azurerm_cdn_frontdoor_route" "main" {
   depends_on                      = [azurerm_cdn_frontdoor_origin_group.main, azurerm_cdn_frontdoor_origin.main]
   for_each                        = toset(var.domains)
@@ -105,7 +59,7 @@ resource "azurerm_cdn_frontdoor_route" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain_association" "main" {
-  for_each                        = toset(var.domains)
+  for_each                       = toset(var.domains)
   cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.main[each.key].id
   cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.main[each.key].id]
 }

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -9,6 +9,14 @@ variable "rule_set_ids" {
   default = null
 }
 
+variable "multiple_hosted_zones" {
+  type = bool
+  default = false
+}
+
 locals {
-  endpoint_zone_name = replace(var.zone, ".education.gov.uk", "")
+  # If true, removes .gov.uk and replaces remaining period with a hypthen e.g. 'domain.education.gov.uk' becomes domain-education.
+  # This works around an issue where two front doors in the same resource group can't have an endpoint with the same name.
+  # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
+  endpoint_zone_name = var.multiple_hosted_zones ? replace(replace(var.zone, ".gov.uk", ""), ".", "-") : replace(var.zone, "/\\..+$/", "")
 }

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -2,6 +2,11 @@ variable "hosted_zone" {
   type = map(any)
 }
 
+variable "deploy_default_records" {
+  type    = bool
+  default = true
+}
+
 variable "tags" {}
 
 locals {
@@ -24,6 +29,6 @@ locals {
   }
 
   hosted_zone_with_records = { for zone_name, zone_cfg in var.hosted_zone :
-    zone_name => merge(zone_cfg, local.default_records)
+    zone_name => merge(zone_cfg, var.deploy_default_records ? local.default_records : null)
   }
 }


### PR DESCRIPTION
### Context
The current module always deployed the same default TXT and CAA records for a DNS zone. It was also not possible to use it with multiple DNS zones and front doors in the same resource group.

### Changes
- Move DNS related resources to the dns file.
- Add a multiple_hosted_zones boolean which can be set to true when we want the endpoint name to be more unique. Its caters for a scenario where there are two DNZ zones, front doors in the same resource group.
- Add a deploy_default_records boolean when we want to specify our own TXT and CAA records for a DNS zone.

### Trello
https://trello.com/c/H6azJvT5

### Testing
The following process was used to test the changes:
https://hackmd.cloudapps.digital/s/BUXSgAxV6#Testing-Process