### PR TITLE
Frontdoor fixes for apply QA

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -28,7 +28,7 @@ resource "azurerm_cdn_frontdoor_origin" "main" {
   certificate_name_check_enabled = true
   enabled                        = true
   host_name                      = var.host_name
-  origin_host_header             = var.host_name
+  origin_host_header             = var.null_host_header == false ? var.host_name : null
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "main" {

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -15,8 +15,10 @@ variable "multiple_hosted_zones" {
 }
 
 locals {
-  # If true, removes .gov.uk and replaces remaining period with a hypthen e.g. 'domain.education.gov.uk' becomes domain-education.
+  # If true, removes .gov.uk and replaces remaining period with a hypthen e.g. 'domain.education.gov.uk' becomes domain-edu.
+  # We shorten the zone name as the fd endpoint name can only be a maximum of 46 chars
   # This works around an issue where two front doors in the same resource group can't have an endpoint with the same name.
   # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
-  endpoint_zone_name = var.multiple_hosted_zones ? replace(replace(var.zone, ".gov.uk", ""), ".", "-") : replace(var.zone, "/\\..+$/", "")
+  short_zone_name = substr(replace(var.zone, "/^[^.]*[.]/", ""), 0, 3)
+  endpoint_zone_name = var.multiple_hosted_zones ? replace(replace(var.zone, "/\\..+$/", "-${local.short_zone_name}"), ".", "-") : replace(var.zone, "/\\..+$/", "")
 }

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -4,6 +4,11 @@ variable "resource_group_name" {}
 variable "domains" {}
 variable "environment" {}
 variable "host_name" {}
+variable "null_host_header" {
+  default     = false
+  description = "The origin_host_header for the azurerm_cdn_frontdoor_origin resource will be var.host_name (if false) or null (if true). If null then the host name from the incoming request will be used."
+}
+
 variable "rule_set_ids" {
   type    = list(any)
   default = null
@@ -15,10 +20,10 @@ variable "multiple_hosted_zones" {
 }
 
 locals {
-  # If true, removes .gov.uk and replaces remaining period with a hypthen e.g. 'domain.education.gov.uk' becomes domain-edu.
+  # If true, removes .gov.uk and replaces remaining period with a hyphen e.g. 'domain.education.gov.uk' becomes domain-edu.
   # We shorten the zone name as the fd endpoint name can only be a maximum of 46 chars
   # This works around an issue where two front doors in the same resource group can't have an endpoint with the same name.
   # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
-  short_zone_name = substr(replace(var.zone, "/^[^.]*[.]/", ""), 0, 3)
-  endpoint_zone_name = var.multiple_hosted_zones ? replace(replace(var.zone, "/\\..+$/", "-${local.short_zone_name}"), ".", "-") : replace(var.zone, "/\\..+$/", "")
+  short_zone_name    = substr(replace(var.zone, "/^[^.]+\\./", ""), 0, 3)
+  endpoint_zone_name = var.multiple_hosted_zones ? replace(var.zone, "/\\..+$/", "-${local.short_zone_name}") : replace(var.zone, "/\\..+$/", "")
 }


### PR DESCRIPTION
### Context
If deploying multiple DNS zones, the FD endpoint name can be larger than 46 chars, 
and the terraform run will fail with error
`Error: "name" must be between 2 and 46 characters in length, begin with a letter or number, end with a letter or number and may contain only letters, numbers and hyphens, got "qa2-assets-apply-for-teacher-training-education"` 

Also add an option to override the origin host header to null, as it defaults to the same value as the host name

### Changes
Create a short_zone_name variable that uses the first 3 chars of the domain after the first period
So qa2-assets-apply-for-teacher-training-education will become qa2-assets-apply-for-teacher-training-edu

Add variable null_host_header with default false.
Setting to true will set a null value for the origin_host_header

### Trello

### Testing
deploy-plan