### PR TITLE
[296] Fix for empty cached path

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -60,7 +60,7 @@ resource "azurerm_cdn_frontdoor_route" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_route" "cached" {
-  for_each                        = var.cached_paths != [] ? toset(var.domains) : toset([])
+  for_each                        = toset(local.cached_domain_list)
   name                            = "${var.environment}-cached-rt"
   cdn_frontdoor_endpoint_id       = azurerm_cdn_frontdoor_endpoint.main[each.key].id
   cdn_frontdoor_origin_group_id   = azurerm_cdn_frontdoor_origin_group.main.id

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -31,4 +31,5 @@ locals {
   # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
   short_zone_name    = substr(replace(var.zone, "/^[^.]+\\./", ""), 0, 3)
   endpoint_zone_name = var.multiple_hosted_zones ? replace(var.zone, "/\\..+$/", "-${local.short_zone_name}") : replace(var.zone, "/\\..+$/", "")
+  cached_domain_list = length(var.cached_paths) > 0 ? var.domains : []
 }


### PR DESCRIPTION
## What
The cached routes are always created since the comparison between 2 empty lists is never equal in terraform
Replace with a condition on the number of elements in the list

## How to review
Run with no cached paths