### PR TITLE
Add AKS Cluster Data module

### DIFF
--- a/aks/cluster_data/README.md
+++ b/aks/cluster_data/README.md
@@ -1,0 +1,50 @@
+# AKS Cluster Data
+
+Terraform module for managing information about the cluster.
+
+## Usage
+
+```terraform
+module "cluster_data" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/cluster_data?ref=stable"
+  name   = var.cluster
+}
+
+provider "kubernetes" {
+  host                   = module.cluster_data.kubernetes_host
+  client_certificate     = module.cluster_data.kubernetes_client_certificate
+  client_key             = module.cluster_data.kubernetes_client_key
+  cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+}
+```
+
+## Outputs
+
+### `configuration_map`
+
+The configuration map for the cluster, an object with the following fields structure:
+
+```terraform
+object({
+  resource_group_name = string
+  resource_prefix     = string
+  dns_zone_prefix     = optional(string)
+  cpu_min             = number
+})
+```
+
+### `kubernetes_host`
+
+The host to use to connect to the Kubernetes cluster.
+
+### `kubernetes_client_certificate`
+
+The client certificate to use to connect to the Kubernetes cluster.
+
+### `kubernetes_client_key`
+
+The client key to use to connect to the Kubernetes cluster.
+
+### `kubenetes_cluster_ca_certificate`
+
+The client cluster CA certificate to use to connect to the Kubernetes cluster.

--- a/aks/cluster_data/data.tf
+++ b/aks/cluster_data/data.tf
@@ -1,0 +1,4 @@
+data "azurerm_kubernetes_cluster" "main" {
+  name                = "${local.configuration_map.resource_prefix}-aks"
+  resource_group_name = local.configuration_map.resource_group_name
+}

--- a/aks/cluster_data/outputs.tf
+++ b/aks/cluster_data/outputs.tf
@@ -1,0 +1,19 @@
+output "configuration_map" {
+  value = local.configuration_map
+}
+
+output "kubernetes_host" {
+  value = data.azurerm_kubernetes_cluster.main.kube_config.0.host
+}
+
+output "kubernetes_client_certificate" {
+  value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)
+}
+
+output "kubernetes_client_key" {
+  value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_key)
+}
+
+output "kubernetes_cluster_ca_certificate" {
+  value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)
+}

--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -1,0 +1,73 @@
+variable "name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+locals {
+  configuration_maps = {
+    cluster1 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster1"
+      dns_zone_prefix     = "cluster1.development"
+      cpu_min             = 0.1
+    }
+
+    cluster2 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster2"
+      dns_zone_prefix     = "cluster2.development"
+      cpu_min             = 0.1
+    }
+
+    cluster3 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster3"
+      dns_zone_prefix     = "cluster3.development"
+      cpu_min             = 0.1
+    }
+
+    cluster4 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster4"
+      dns_zone_prefix     = "cluster4.development"
+      cpu_min             = 0.1
+    }
+
+    cluster5 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster5"
+      dns_zone_prefix     = "cluster5.development"
+      cpu_min             = 0.1
+    }
+
+    cluster6 = {
+      resource_group_name = "s189d01-tsc-dv-rg"
+      resource_prefix     = "s189d01-tsc-cluster6"
+      dns_zone_prefix     = "cluster6.development"
+      cpu_min             = 0.1
+    }
+
+    test = {
+      resource_group_name = "s189t01-tsc-ts-rg"
+      resource_prefix     = "s189t01-tsc-test"
+      dns_zone_prefix     = "test"
+      cpu_min             = 0.1
+    }
+
+    platform-test = {
+      resource_group_name = "s189t01-tsc-pt-rg"
+      resource_prefix     = "s189t01-tsc-platform-test"
+      dns_zone_prefix     = "platform-test"
+      cpu_min             = 0.1
+    }
+
+    production = {
+      resource_group_name = "s189p01-tsc-pd-rg"
+      resource_prefix     = "s189p01-tsc-production"
+      dns_zone_prefix     = null
+      cpu_min             = 1
+    }
+  }
+
+  configuration_map = local.configuration_maps[var.name]
+}


### PR DESCRIPTION
This adds a Terraform module for capturing the various AKS clusters we have configured and keeps it one place, shareable across multiple users of AKS.

Based on the notes: https://hackmd.cloudapps.digital/k9xWr1eDQ86ffMusLO2zPA