### PR TITLE
Improve release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ !github.event.release.prerelease }}
     steps:
       - uses: actions/checkout@v3
-        with: {ref: "${{ github.event.release.target_commitish }}"}
+        with: {ref: "${{ github.event.release.tag_name }}"}
       - uses: EndBug/latest-tag@latest
         with: {ref: stable}
 
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with: {ref: "${{ github.event.release.target_commitish }}"}
+        with: {ref: "${{ github.event.release.tag_name }}"}
       - uses: EndBug/latest-tag@latest
         with: {ref: testing}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
   update-testing-tag:
     name: Update testing tag
     runs-on: ubuntu-latest
-    if: ${{ github.event.release.prerelease }}
     steps:
       - uses: actions/checkout@v3
         with: {ref: "${{ github.event.release.target_commitish }}"}


### PR DESCRIPTION
This makes two small changes to improve the release process:

- **Always update testing tag**: This ensures that even when a stable release is made, the `testing` tag is updated. Without this we can end up in situations where `stable` is more recent than `testing`.
- **Use tag name to checkout repo**: Using the target commitish doesn't quite work as it represents where the Git tag is created from. This works if the tag is new with the release, but not if we're releasing an existing tag.
