### PR TITLE
337 terraform modules fix redis output to create explicit dependencies

### DIFF
--- a/aks/redis/output.tf
+++ b/aks/redis/output.tf
@@ -1,4 +1,4 @@
 output "url" {
-  value     = var.use_azure ? "rediss://:${azurerm_redis_cache.main[0].primary_access_key}@${azurerm_redis_cache.main[0].hostname}:${azurerm_redis_cache.main[0].ssl_port}/0" : "redis://${local.kubernetes_name}:6379/0"
+  value     = var.use_azure ? "rediss://:${azurerm_redis_cache.main[0].primary_access_key}@${azurerm_redis_cache.main[0].hostname}:${azurerm_redis_cache.main[0].ssl_port}/0" : "redis://${kubernetes_service.main[0].metadata[0].name}:6379/0"
   sensitive = true
 }

--- a/aks/redis/output.tf
+++ b/aks/redis/output.tf
@@ -1,4 +1,4 @@
 output "url" {
-  value     = var.use_azure ? "rediss://:${azurerm_redis_cache.main[0].primary_access_key}@${azurerm_redis_cache.main[0].hostname}:${azurerm_redis_cache.main[0].ssl_port}/0" : "redis://${kubernetes_service.main[0].metadata[0].name}:6379/0"
+  value     = var.use_azure ? "rediss://:${azurerm_redis_cache.main[0].primary_access_key}@${azurerm_private_endpoint.main[0].private_dns_zone_configs[0].record_sets[0].name}.redis.cache.windows.net:${azurerm_redis_cache.main[0].ssl_port}/0" : "redis://${kubernetes_service.main[0].metadata[0].name}:6379/0"
   sensitive = true
 }

--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -162,7 +162,8 @@ resource "kubernetes_service" "main" {
       port = 6379
     }
     selector = {
-      app = local.kubernetes_name
+      # Gets the exact label from kubernetes deployment resource to force an explicit dependancy to create deployment before service
+      app = kubernetes_deployment.main[0].spec[0].template[0].metadata[0].labels["app"]
     }
   }
 }


### PR DESCRIPTION
### Context
Dependencies need to be explicity created so that Redis URLs are ready for the service to pick up.

### Changes proposed in this pull request
* Added dependency on kubernetes redis service in the redis url output for aks
* Added dependency on azure private endpoint in the redis url output for azure
* Added dependency for kubenetes redis service to depend on kubernetes redis deployment

### Guidance to review
Use the commit id ```e4f1459d3b339890a6711c18e801cdc676de5f65   ``` as a reference to the module and run terraform 