### PR TITLE
Uodate ingress name

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -152,7 +152,7 @@ resource "kubernetes_ingress_v1" "main" {
   wait_for_load_balancer = true
 
   metadata {
-    name      = local.app_name
+    name      = each.value
     namespace = var.namespace
   }
 


### PR DESCRIPTION
Update the name of the ingress so when we have more than one ingress for a service, the name can be unique based on the hostname. Otherwise the additional ingress resources failt to create because the names are the same