### PR TITLE
308 manage ect domain improvements

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -6,7 +6,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
   for_each = toset(var.domains)
 
-  name                     = "${each.value}-${local.endpoint_zone_name}"
+  name                     = substr("${each.value}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
   lifecycle {
     ignore_changes = [

--- a/domains/environment_domains/locals.tf
+++ b/domains/environment_domains/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  # If true, removes .gov.uk and replaces remaining period with a hyphen e.g. 'domain.education.gov.uk' becomes domain-edu.
+  # We shorten the zone name as the fd endpoint name can only be a maximum of 46 chars
+  # This works around an issue where two front doors in the same resource group can't have an endpoint with the same name.
+  # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
+  short_zone_name    = substr(replace(var.zone, "/^[^.]+\\./", ""), 0, 3)
+  endpoint_zone_name = var.multiple_hosted_zones ? replace(var.zone, "/\\..+$/", "-${local.short_zone_name}") : replace(var.zone, "/\\..+$/", "")
+
+  cached_domain_list = length(var.cached_paths) > 0 ? var.domains : []
+
+  max_frontdoor_endpoint_name_length = 46
+}

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -18,18 +18,9 @@ variable "multiple_hosted_zones" {
   type    = bool
   default = false
 }
+
 variable "cached_paths" {
   type        = list(string)
   default     = []
   description = "List of path patterns such as /packs/* that front door will cache"
-}
-
-locals {
-  # If true, removes .gov.uk and replaces remaining period with a hyphen e.g. 'domain.education.gov.uk' becomes domain-edu.
-  # We shorten the zone name as the fd endpoint name can only be a maximum of 46 chars
-  # This works around an issue where two front doors in the same resource group can't have an endpoint with the same name.
-  # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
-  short_zone_name    = substr(replace(var.zone, "/^[^.]+\\./", ""), 0, 3)
-  endpoint_zone_name = var.multiple_hosted_zones ? replace(var.zone, "/\\..+$/", "-${local.short_zone_name}") : replace(var.zone, "/\\..+$/", "")
-  cached_domain_list = length(var.cached_paths) > 0 ? var.domains : []
 }


### PR DESCRIPTION
### Context

Some of the domains for services are quite long (e.g. manage-training-for-early-career-teachers.education.gov.uk) and can exceed the allowed length of 46 characters when made in to the front door endpoint name. This ensures the name is never longer by removing excess characters once the name has been generated by the module.

### Changes in this Pull Request
Add a variable to define the max name size.
Use the substr function to reduce the length of the front door endpoint name if required

### Impact

This shouldn't impact any existing deployments because they will all be under the 46 character length limit already.