### PR TITLE
Introduce topology contracts into the resource module

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -31,6 +31,26 @@ resource "kubernetes_deployment" "main" {
           "teacherservices.cloud/node_pool" = "applications"
           "kubernetes.io/os"                = "linux"
         }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "topology.kubernetes.io/zone"
+          when_unsatisfiable = "DoNotSchedule"
+          label_selector {
+            match_labels = {
+              app = local.app_name
+            }
+          }
+        }
+        topology_spread_constraint {
+          max_skew           = 1
+          topology_key       = "kubernetes.io/hostname"
+          when_unsatisfiable = "ScheduleAnyway"
+          label_selector {
+            match_labels = {
+              app = local.app_name
+            }
+          }
+        }
 
         container {
           name    = local.app_name


### PR DESCRIPTION
This is to introduce redundancy by adding the zone and hostname constraints. 
The default value for max_skew is set to 1, the topology key is left as default values and so is the when_unsatisfiable value