### PR TITLE
Add Kubernetes pod disruption budget resource to application module

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -195,3 +195,20 @@ resource "kubernetes_ingress_v1" "main" {
     }
   }
 }
+
+resource "kubernetes_pod_disruption_budget_v1" "main" {
+  count = var.replicas > 1 ? 1 : 0
+
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+  }
+  spec {
+    min_available = "50%"
+    selector {
+      match_labels = {
+        app = local.app_name
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Context
Add Kubernetes Pod Distribution budget to application module. 

### Changes proposed in this pull request
* Added Kubernetes Pod Distribution Budget
* Resource should only be created if the number of replicas is above 1. 
* For the time being we should stick with using 50% as the min_available replicas.

### Testing 
Tested with register app

### Guidance to review
Change Terrafile to reference this branch (344-terraform-modules-add-kubernetes-pod-distribution-budget-to-application-module) for version.
Change the number of replicas to above 1 for your proffered environment var file and deploy the app to see that PDB is created and 50% is set. Below 1 replicas should not create PDB. 