### PR TITLE
[347] Allow empty list of postgres extensions

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -78,7 +78,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
 }
 
 resource "azurerm_postgresql_flexible_server_configuration" "azure_extensions" {
-  count = var.use_azure ? 1 : 0
+  count = var.use_azure && length(var.azure_extensions) > 0 ? 1 : 0
 
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.main[0].id


### PR DESCRIPTION
## What
Solves error when using default empty list:

```
│ Error: expected "value" to not be an empty string, got │
│   with module.postgres.azurerm_postgresql_flexible_server_configuration.azure_extensions[0],
│   on vendor/modules/aks/aks/postgres/resources.tf line 85, in resource "azurerm_postgresql_flexible_server_configuration" "azure_extensions":
│   85:   value     = join(",", var.azure_extensions)
```

## How to review
See https://github.com/DFE-Digital/teacher-services-hedgedoc/blob/main/terraform/database.tf#L1