### PR TITLE
make aks postgres backup storage account optional

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -103,7 +103,7 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
 }
 
 resource "azurerm_storage_account" "backup" {
-  count = var.use_azure ? 1 : 0
+  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
 
   name                     = "${var.azure_resource_prefix}${var.service_short}dbbkp${var.config_short}sa"
   location                 = data.azurerm_resource_group.main[0].location
@@ -115,7 +115,7 @@ resource "azurerm_storage_account" "backup" {
 }
 
 resource "azurerm_storage_management_policy" "backup" {
-  count = var.use_azure ? 1 : 0
+  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
 
   storage_account_id = azurerm_storage_account.backup[0].id
 
@@ -134,7 +134,7 @@ resource "azurerm_storage_management_policy" "backup" {
 }
 
 resource "azurerm_storage_container" "backup" {
-  count = var.use_azure ? 1 : 0
+  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
 
   name                  = "database-backup"
   storage_account_name  = azurerm_storage_account.backup[0].name

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -111,3 +111,8 @@ variable "azure_maintenance_window" {
   })
   default = null
 }
+
+variable "azure_backup_storage_account" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
## What
For the aks postgres module, we don't always want additional backups.
So make the backup resources optional, with default true.
- storage account
- container
- lifecycle policy

## How to review
make using branch