### PR TITLE
Use full names for AKS databases

### DIFF
--- a/aks/postgres/README.md
+++ b/aks/postgres/README.md
@@ -13,8 +13,9 @@ module "postgres" {
   namespace             = var.namespace
   environment           = "${var.app_environment}${var.app_suffix}"
   azure_resource_prefix = var.azure_resource_prefix
-  service_short         = var.service_short
-  config_short          = var.config_short
+  service_name          = "apply-for-qts"
+  service_short         = "afqts"
+  config_short          = "dv"
 
   cluster_configuration_map = module.aks_cluster_data.configuration_map
 

--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -6,7 +6,7 @@ locals {
   azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}"
   azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}-pe"
 
-  kubernetes_name = "${var.service_short}-${var.environment}-postgres${local.name_suffix}"
+  kubernetes_name = "${var.service_name}-${var.environment}-postgres${local.name_suffix}"
 }
 
 # Username & password

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -19,6 +19,11 @@ variable "azure_resource_prefix" {
   description = "Prefix of Azure resources for the service"
 }
 
+variable "service_name" {
+  type        = string
+  description = "Name of the service"
+}
+
 variable "service_short" {
   type        = string
   description = "Short name of the service"

--- a/aks/redis/README.md
+++ b/aks/redis/README.md
@@ -13,8 +13,9 @@ module "redis" {
   namespace             = var.namespace
   environment           = "${var.app_environment}${var.app_suffix}"
   azure_resource_prefix = var.azure_resource_prefix
-  service_short         = var.service_short
-  config_short          = var.config_short
+  service_name          = "apply-for-qts"
+  service_short         = "afqts"
+  config_short          = "dv"
 
   cluster_configuration_map = module.aks_cluster_data.configuration_map
 

--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -4,7 +4,7 @@ locals {
   azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-redis${local.name_suffix}"
   azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-redis${local.name_suffix}-pe"
 
-  kubernetes_name = "${var.service_short}-${var.environment}-redis${local.name_suffix}"
+  kubernetes_name = "${var.service_name}-${var.environment}-redis${local.name_suffix}"
 }
 
 # Azure

--- a/aks/redis/variables.tf
+++ b/aks/redis/variables.tf
@@ -19,6 +19,11 @@ variable "azure_resource_prefix" {
   description = "Prefix of Azure resources for the service"
 }
 
+variable "service_name" {
+  type        = string
+  description = "Name of the service"
+}
+
 variable "service_short" {
   type        = string
   description = "Short name of the service"


### PR DESCRIPTION
At the moment we use the short name for databases created in Kubernetes, which ends up with a set of deployments like this:

```
afqts-review-1445-postgres         1/1     1            1           2d22h
afqts-review-1445-redis            1/1     1            1           2d22h
afqts-review-1451-postgres         1/1     1            1           59m
afqts-review-1451-redis            1/1     1            1           59m
apply-for-qts-development-web      1/1     1            1           46m
apply-for-qts-development-worker   1/1     1            1           46m
apply-for-qts-review-1445-web      1/1     1            1           2d22h
apply-for-qts-review-1445-worker   1/1     1            1           2d22h
apply-for-qts-review-1451-web      1/1     1            1           59m
apply-for-qts-review-1451-worker   1/1     1            1           59m
```

This is slightly unclear when first viewing, as the deployments associated with a particular environment aren't grouped together or named consistently. Using the full name should help make this more readable and match the application deployments.