### PR TITLE
Add outputs for backup storage

### DIFF
--- a/aks/postgres/README.md
+++ b/aks/postgres/README.md
@@ -50,3 +50,11 @@ The name of the database.
 ### `url`
 
 The URL used to connect to the PostgreSQL instance.
+
+### `azure_backup_storage_account_name`
+
+The name of the storage account that can be used to store backups.
+
+### `azure_backup_storage_container_name`
+
+The name of the storage container that can be used to store backups.

--- a/aks/postgres/outputs.tf
+++ b/aks/postgres/outputs.tf
@@ -29,3 +29,11 @@ output "url" {
   value     = "postgres://${urlencode(local.database_username)}:${urlencode(local.database_password)}@${local.host}:${local.port}/${local.database_name}"
   sensitive = true
 }
+
+output "azure_backup_storage_account_name" {
+  value = local.azure_enable_backup_storage ? azurerm_storage_account.backup[0].name : null
+}
+
+output "azure_backup_storage_container_name" {
+  value = local.azure_enable_backup_storage ? azurerm_storage_container.backup[0].name : null
+}

--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -5,6 +5,7 @@ locals {
 
   azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}"
   azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}-pe"
+  azure_enable_backup_storage = var.use_azure && var.azure_enable_backup_storage
 
   kubernetes_name = "${var.service_name}-${var.environment}-postgres${local.name_suffix}"
 }
@@ -103,7 +104,7 @@ resource "azurerm_postgresql_flexible_server_database" "main" {
 }
 
 resource "azurerm_storage_account" "backup" {
-  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
+  count = local.azure_enable_backup_storage ? 1 : 0
 
   name                     = "${var.azure_resource_prefix}${var.service_short}dbbkp${var.config_short}sa"
   location                 = data.azurerm_resource_group.main[0].location
@@ -115,7 +116,7 @@ resource "azurerm_storage_account" "backup" {
 }
 
 resource "azurerm_storage_management_policy" "backup" {
-  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
+  count = local.azure_enable_backup_storage ? 1 : 0
 
   storage_account_id = azurerm_storage_account.backup[0].id
 
@@ -134,7 +135,7 @@ resource "azurerm_storage_management_policy" "backup" {
 }
 
 resource "azurerm_storage_container" "backup" {
-  count = var.use_azure && var.azure_backup_storage_account ? 1 : 0
+  count = local.azure_enable_backup_storage ? 1 : 0
 
   name                  = "database-backup"
   storage_account_name  = azurerm_storage_account.backup[0].name

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -117,7 +117,7 @@ variable "azure_maintenance_window" {
   default = null
 }
 
-variable "azure_backup_storage_account" {
+variable "azure_enable_backup_storage" {
   type    = bool
   default = true
 }


### PR DESCRIPTION
This allows us to get the name of the storage account and storage container so we know where to upload backups to from GitHub Actions.