### PR TITLE
Improve monitoring action group naming

### DIFF
--- a/aks/postgres/README.md
+++ b/aks/postgres/README.md
@@ -25,6 +25,13 @@ module "postgres" {
 }
 ```
 
+### Monitoring
+
+If `azure_enable_monitoring` is `true`, it’s expected that the following resources already exist:
+
+- A resource group named `${azure_resource_prefix}-${service_short}-mn-rg` (where `mn` stands for monitoring and `rg` stands for resource group).
+- A monitor action group named `${azure_resource_prefix}-${service_name}` within the above resource group.
+
 ## Outputs
 
 ### `username`

--- a/aks/postgres/data.tf
+++ b/aks/postgres/data.tf
@@ -20,7 +20,7 @@ data "azurerm_private_dns_zone" "main" {
 }
 
 data "azurerm_monitor_action_group" "main" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${data.azurerm_resource_group.main[0].name}-monitoring"
   resource_group_name = data.azurerm_resource_group.main[0].name

--- a/aks/postgres/data.tf
+++ b/aks/postgres/data.tf
@@ -22,6 +22,6 @@ data "azurerm_private_dns_zone" "main" {
 data "azurerm_monitor_action_group" "main" {
   count = local.azure_enable_monitoring ? 1 : 0
 
-  name                = "${data.azurerm_resource_group.main[0].name}-monitoring"
+  name                = "${var.azure_resource_prefix}-${var.service_name}"
   resource_group_name = data.azurerm_resource_group.main[0].name
 }

--- a/aks/postgres/data.tf
+++ b/aks/postgres/data.tf
@@ -19,9 +19,15 @@ data "azurerm_private_dns_zone" "main" {
   resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
 }
 
+data "azurerm_resource_group" "monitoring" {
+  count = local.azure_enable_monitoring ? 1 : 0
+
+  name = "${var.azure_resource_prefix}-${var.service_short}-mn-rg"
+}
+
 data "azurerm_monitor_action_group" "main" {
   count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${var.azure_resource_prefix}-${var.service_name}"
-  resource_group_name = data.azurerm_resource_group.main[0].name
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
 }

--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -6,6 +6,7 @@ locals {
   azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}"
   azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}-pe"
   azure_enable_backup_storage = var.use_azure && var.azure_enable_backup_storage
+  azure_enable_monitoring     = var.use_azure && var.azure_enable_monitoring
 
   kubernetes_name = "${var.service_name}-${var.environment}-postgres${local.name_suffix}"
 }
@@ -143,7 +144,7 @@ resource "azurerm_storage_container" "backup" {
 }
 
 resource "azurerm_monitor_metric_alert" "memory" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${azurerm_postgresql_flexible_server.main[0].name}-memory"
   resource_group_name = data.azurerm_resource_group.main[0].name
@@ -170,7 +171,7 @@ resource "azurerm_monitor_metric_alert" "memory" {
 }
 
 resource "azurerm_monitor_metric_alert" "cpu" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${azurerm_postgresql_flexible_server.main[0].name}-cpu"
   resource_group_name = data.azurerm_resource_group.main[0].name
@@ -197,7 +198,7 @@ resource "azurerm_monitor_metric_alert" "cpu" {
 }
 
 resource "azurerm_monitor_metric_alert" "storage" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${azurerm_postgresql_flexible_server.main[0].name}-storage"
   resource_group_name = data.azurerm_resource_group.main[0].name

--- a/aks/redis/README.md
+++ b/aks/redis/README.md
@@ -23,6 +23,13 @@ module "redis" {
 }
 ```
 
+### Monitoring
+
+If `azure_enable_monitoring` is `true`, it’s expected that the following resources already exist:
+
+- A resource group named `${azure_resource_prefix}-${service_short}-mn-rg` (where `mn` stands for monitoring and `rg` stands for resource group).
+- A monitor action group named `${azure_resource_prefix}-${service_name}` within the above resource group.
+
 ## Outputs
 
 ### `url`

--- a/aks/redis/data.tf
+++ b/aks/redis/data.tf
@@ -20,7 +20,7 @@ data "azurerm_private_dns_zone" "main" {
 }
 
 data "azurerm_monitor_action_group" "main" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${data.azurerm_resource_group.main[0].name}-monitoring"
   resource_group_name = data.azurerm_resource_group.main[0].name

--- a/aks/redis/data.tf
+++ b/aks/redis/data.tf
@@ -22,6 +22,6 @@ data "azurerm_private_dns_zone" "main" {
 data "azurerm_monitor_action_group" "main" {
   count = local.azure_enable_monitoring ? 1 : 0
 
-  name                = "${data.azurerm_resource_group.main[0].name}-monitoring"
+  name                = "${var.azure_resource_prefix}-${var.service_name}"
   resource_group_name = data.azurerm_resource_group.main[0].name
 }

--- a/aks/redis/data.tf
+++ b/aks/redis/data.tf
@@ -19,9 +19,15 @@ data "azurerm_private_dns_zone" "main" {
   resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
 }
 
+data "azurerm_resource_group" "monitoring" {
+  count = local.azure_enable_monitoring ? 1 : 0
+
+  name = "${var.azure_resource_prefix}-${var.service_short}-mn-rg"
+}
+
 data "azurerm_monitor_action_group" "main" {
   count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${var.azure_resource_prefix}-${var.service_name}"
-  resource_group_name = data.azurerm_resource_group.main[0].name
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
 }

--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -3,6 +3,7 @@ locals {
 
   azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-redis${local.name_suffix}"
   azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-redis${local.name_suffix}-pe"
+  azure_enable_monitoring     = var.use_azure && var.azure_enable_monitoring
 
   kubernetes_name = "${var.service_name}-${var.environment}-redis${local.name_suffix}"
 }
@@ -76,7 +77,7 @@ resource "azurerm_private_endpoint" "main" {
 }
 
 resource "azurerm_monitor_metric_alert" "memory" {
-  count = var.use_azure && var.azure_enable_monitoring ? 1 : 0
+  count = local.azure_enable_monitoring ? 1 : 0
 
   name                = "${azurerm_redis_cache.main[0].name}-memory"
   resource_group_name = data.azurerm_resource_group.main[0].name


### PR DESCRIPTION
This changes the naming of the monitoring action group to reflect the fact that there can only be one per subscription, and ensure that it has its own resource group.