### PR TITLE
Add variables for Rails applications

### DIFF
--- a/aks/application_configuration/README.md
+++ b/aks/application_configuration/README.md
@@ -21,6 +21,15 @@ module "application_configuration" {
 }
 ```
 
+### Rails applications
+
+If `is_rails_application` is set to `true`, this will automatically set the following config variables:
+
+```sh
+RAILS_SERVE_STATIC_FILES=true
+RAILS_LOG_TO_STDOUT=true
+```
+
 ## Outputs
 
 ### `kubernetes_config_map_name`

--- a/aks/application_configuration/resources.tf
+++ b/aks/application_configuration/resources.tf
@@ -1,5 +1,11 @@
 locals {
+  rails_config_map_data = {
+    RAILS_SERVE_STATIC_FILES = "true",
+    RAILS_LOG_TO_STDOUT      = "true"
+  }
+
   config_map_data = merge(
+    var.is_rails_application ? local.rails_config_map_data : {},
     try(yamldecode(file(var.config_variables_path)), {}),
     var.config_variables,
   )

--- a/aks/application_configuration/variables.tf
+++ b/aks/application_configuration/variables.tf
@@ -25,8 +25,14 @@ variable "config_short" {
 
 variable "key_vault_secret_name" {
   type        = string
-  description = "Secret name of the key vault to load secrets from"
   default     = "APPLICATION"
+  description = "Secret name of the key vault to load secrets from"
+}
+
+variable "is_rails_application" {
+  type        = bool
+  default     = false
+  description = "If true, sets config variables for a Rails application"
 }
 
 variable "config_variables" {


### PR DESCRIPTION
This adds a new argument to the application configuration module allowing it to set some sensible default config variables for Rails applications.