### PR TITLE
Allow overriding the Key Vault name

### DIFF
--- a/aks/application_configuration/data.tf
+++ b/aks/application_configuration/data.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault" "main" {
-  name                = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-kv"
+  name                = var.key_vault_name != null ? var.key_vault_name : "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-kv"
   resource_group_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
 }
 

--- a/aks/application_configuration/variables.tf
+++ b/aks/application_configuration/variables.tf
@@ -23,6 +23,12 @@ variable "config_short" {
   description = "Short name of the configuration"
 }
 
+variable "key_vault_name" {
+  type        = string
+  default     = null
+  description = "Overrides the default Key Vault name. The default is $${var.azure_resource_prefix}-$${var.service_short}-$${var.config_short}-kv"
+}
+
 variable "key_vault_secret_name" {
   type        = string
   default     = "APPLICATION"


### PR DESCRIPTION
In setting up the DQT API on AKS, I created a Key Vault in the incorrect region by mistake. It turns out you cannot move a Key Vault to another region and since we have purge protection enabled I cannot delete the Key Vault and recreate it in the correct region for 3 months.

This change adds an optional variable to enable overriding the default Key Vault name.