### PR TITLE
Specify required providers

### DIFF
--- a/aks/application/terraform.tf
+++ b/aks/application/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.53"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}

--- a/aks/application_configuration/terraform.tf
+++ b/aks/application_configuration/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}

--- a/aks/cluster_data/terraform.tf
+++ b/aks/cluster_data/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.53"
+    }
+  }
+}

--- a/aks/postgres/terraform.tf
+++ b/aks/postgres/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.53"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}

--- a/aks/redis/terraform.tf
+++ b/aks/redis/terraform.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.53"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+  }
+}


### PR DESCRIPTION
This ensures that each AKS module specifies the providers it requires, and where to find them. This is not strictly necessary if the root module (the service's Terraform code) already defines these, but it's good practice to put these in the modules as well.