### PR TITLE
Revert "Add StatusCake alerts"

### DIFF
--- a/aks/application/README.md
+++ b/aks/application/README.md
@@ -43,10 +43,6 @@ module "worker_application" {
 }
 ```
 
-### Health checks
-
-For web applications, the default `probe_path` is set to `/healthcheck`. Set `enable_statuscake` to `true` to add StatusCake uptime alerts as well.
-
 ## Outputs
 
 ### `hostname`

--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -1,10 +1,7 @@
 locals {
   name_suffix = var.name != null ? "-${var.name}" : ""
-  app_name    = "${var.service_name}-${var.environment}${local.name_suffix}"
 
-  http_probe_enabled = var.is_web && var.probe_path != null
-  exec_probe_enabled = !var.is_web && length(var.probe_command) != 0
-  probe_enabled      = local.http_probe_enabled || local.exec_probe_enabled
+  app_name = "${var.service_name}-${var.environment}${local.name_suffix}"
 }
 
 resource "kubernetes_deployment" "main" {
@@ -213,33 +210,5 @@ resource "kubernetes_pod_disruption_budget_v1" "main" {
         app = local.app_name
       }
     }
-  }
-}
-
-locals {
-  statuscake_enabled   = local.http_probe_enabled && var.enable_statuscake
-  statuscake_hostnames = local.statuscake_enabled ? local.hostnames : []
-}
-
-resource "statuscake_uptime_check" "main" {
-  for_each = local.statuscake_hostnames
-
-  name           = each.value
-  contact_groups = var.statuscake_contact_groups
-  confirmation   = 2
-  trigger_rate   = 0
-  check_interval = 30
-  regions        = ["london", "dublin"]
-
-  http_check {
-    follow_redirects = true
-    timeout          = 40
-    request_method   = "HTTP"
-    status_codes     = ["204", "205", "206", "303", "400", "401", "403", "404", "405", "406", "408", "410", "413", "444", "429", "494", "495", "496", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "521", "522", "523", "524", "520", "598", "599"]
-    validate_ssl     = false
-  }
-
-  monitored_resource {
-    address = "https://${each.value}${var.probe_path}"
   }
 }

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -82,7 +82,7 @@ variable "web_port" {
 
 variable "probe_path" {
   type        = string
-  default     = "/healthcheck"
+  default     = null
   description = "Path for the liveness and startup probe"
 }
 
@@ -92,14 +92,8 @@ variable "probe_command" {
   description = "Command for the liveness and startup probe"
 }
 
-variable "enable_statuscake" {
-  type        = bool
-  default     = false
-  description = "Whether to set up StatusCake alerts for web applications"
-}
-
-variable "statuscake_contact_groups" {
-  type        = list(string)
-  default     = []
-  description = "Contact groups for the StatusCake alerts"
+locals {
+  http_probe_enabled = var.is_web && var.probe_path != null
+  exec_probe_enabled = !var.is_web && length(var.probe_command) != 0
+  probe_enabled      = local.http_probe_enabled || local.exec_probe_enabled
 }


### PR DESCRIPTION
Reverts DFE-Digital/terraform-modules#33

This doesn't work very well because Terraform tries to construct the `statuscake` provider even if an application isn't using it.