### PR TITLE
Add StatusCake monitoring module

### DIFF
--- a/aks/application/README.md
+++ b/aks/application/README.md
@@ -48,3 +48,11 @@ module "worker_application" {
 ### `hostname`
 
 The hostname of the deployed application.
+
+### `url`
+
+The URL of the deployed application.
+
+### `probe_url`
+
+The URL of the deployed application combined with the probe path.

--- a/aks/application/outputs.tf
+++ b/aks/application/outputs.tf
@@ -1,3 +1,11 @@
 output "hostname" {
   value = local.hostname
 }
+
+output "url" {
+  value = "https://${local.hostname}"
+}
+
+output "probe_url" {
+  value = var.probe_path != null ? "https://${local.hostname}${var.probe_path}" : null
+}

--- a/monitoring/statuscake/README.md
+++ b/monitoring/statuscake/README.md
@@ -1,0 +1,18 @@
+# StatusCake monitoring
+
+Terraform code for deploying StatusCake uptime and SSL checks.
+
+## Usage
+
+```terraform
+module "statuscake" {
+  count = var.enable_statuscake ? 1 : 0
+
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//monitoring/statuscake?ref=stable"
+
+  uptime_urls = [module.web_application.probe_url, "https://#{var.external_hostname}"]
+  ssl_urls    = ["https://#{var.external_hostname}"]
+
+  contact_groups = var.statuscake_contact_groups
+}
+```

--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -1,0 +1,43 @@
+resource "statuscake_uptime_check" "main" {
+  for_each = toset(var.uptime_urls)
+
+  name           = each.value
+  contact_groups = var.contact_groups
+  confirmation   = 2
+  trigger_rate   = 0
+  check_interval = 30
+  regions        = ["london", "dublin"]
+
+  http_check {
+    follow_redirects = true
+    timeout          = 40
+    request_method   = "HTTP"
+    status_codes     = ["204", "205", "206", "303", "400", "401", "403", "404", "405", "406", "408", "410", "413", "444", "429", "494", "495", "496", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "521", "522", "523", "524", "520", "598", "599"]
+    validate_ssl     = false
+  }
+
+  monitored_resource {
+    address = each.value
+  }
+}
+
+resource "statuscake_ssl_check" "main" {
+  for_each = toset(var.ssl_urls)
+
+  contact_groups   = var.contact_groups
+  check_interval   = 3600
+  follow_redirects = true
+
+  alert_config {
+    alert_at = [3, 7, 30] # 1 month, 1 week then 3 days before expiration
+
+    on_reminder = true
+    on_expiry   = true
+    on_broken   = true
+    on_mixed    = true
+  }
+
+  monitored_resource {
+    address = each.value
+  }
+}

--- a/monitoring/statuscake/terraform.tf
+++ b/monitoring/statuscake/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    statuscake = {
+      source  = "StatusCakeDev/statuscake"
+      version = ">= 2.1"
+    }
+  }
+}

--- a/monitoring/statuscake/variables.tf
+++ b/monitoring/statuscake/variables.tf
@@ -1,0 +1,17 @@
+variable "uptime_urls" {
+  type        = list(string)
+  description = "Set of URLs to perform uptime checks on"
+  default     = []
+}
+
+variable "ssl_urls" {
+  type        = list(string)
+  description = "Set of URLs to perform SSL checks on"
+  default     = []
+}
+
+variable "contact_groups" {
+  type        = list(string)
+  description = "Contact groups for the alerts"
+  default     = []
+}


### PR DESCRIPTION
This adds a module which implements StatusCake uptime checks. It accepts a list of URLs to check and a list of contact groups.

This replaces #33 as we had issues with services not using StatusCake.