### PR TITLE
Remove periods from multilevel subdomain resource names

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -6,7 +6,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
   for_each = toset(var.domains)
 
-  name                     = substr("${each.value}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
+  name                     = substr("${replace(each.value, ".", "-")}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
   lifecycle {
     ignore_changes = [
@@ -33,7 +33,7 @@ resource "azurerm_cdn_frontdoor_origin" "main" {
 
 resource "azurerm_cdn_frontdoor_custom_domain" "main" {
   for_each                 = toset(var.domains)
-  name                     = each.key
+  name                     = replace(each.key, ".", "-")
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
   dns_zone_id              = data.azurerm_dns_zone.main.id
   host_name                = each.key == "apex" ? "${var.zone}" : "${each.key}.${var.zone}"


### PR DESCRIPTION
### Context
Currently if I want to add configure additional front door resources using a multilevel subdomain the module errors because the name contains a period (.) which are not allowed. This PR removes the period from the name of resources that would be used to define multilevel subdomains of the main domain e.g. qa2.api.

### Changes proposed in this pull request

- Update the front door endpoint resource name to remove the period
- Update the front door custom domain resource name to remove the period

### Testing

- [ ] Execute `make publish ENV domains-plan` to confirm there are no other changes except where a multilevel domain is now able to be defined in the `var.domains` variable