### PR TITLE
Add a .NET-compatible connection string to Postgres outputs

### DIFF
--- a/aks/postgres/README.md
+++ b/aks/postgres/README.md
@@ -58,6 +58,10 @@ The name of the database.
 
 The URL used to connect to the PostgreSQL instance.
 
+### `dotnet_connection_string`
+
+A connection string that's compatible with .NET applications to the PostgreSQL instance.
+
 ### `azure_backup_storage_account_name`
 
 The name of the storage account that can be used to store backups.

--- a/aks/postgres/outputs.tf
+++ b/aks/postgres/outputs.tf
@@ -30,6 +30,11 @@ output "url" {
   sensitive = true
 }
 
+output "dotnet_connection_string" {
+  value     = "Server=${local.host};Database=${local.database_name};Port=${local.port};User Id=${local.database_username};Password='${local.database_password}';Ssl Mode=Require;Trust Server Certificate=true"
+  sensitive = true
+}
+
 output "azure_backup_storage_account_name" {
   value = local.azure_enable_backup_storage ? azurerm_storage_account.backup[0].name : null
 }


### PR DESCRIPTION
Similar to the Redis module, the `url` output is in a format that .NET applications cannot use. This adds a .NET compatible connection string to the outputs. Unlike the Redis module, this connection string *is* .NET specific and so I've named it `dotnet_connection_string`.