### PR TITLE
[448] Make domain tags optional

### DIFF
--- a/dns/zones/resources.tf
+++ b/dns/zones/resources.tf
@@ -7,6 +7,8 @@ resource "azurerm_dns_zone" "dns_zone" {
   resource_group_name = each.value.resource_group_name
 
   tags = var.tags
+
+  lifecycle { ignore_changes = [tags] }
 }
 
 # CAA record

--- a/dns/zones/variables.tf
+++ b/dns/zones/variables.tf
@@ -6,7 +6,9 @@ variable "hosted_zone" {
   default = {}
 }
 
-variable "tags" {}
+variable "tags" {
+  default = null
+}
 
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials), null)

--- a/domains/infrastructure/dns.tf
+++ b/domains/infrastructure/dns.tf
@@ -1,5 +1,5 @@
 module "dns" {
-  source      = "git::https://github.com/DFE-Digital/terraform-modules.git//dns/zones?ref=0.5.2"
+  source      = "../../dns/zones"
   hosted_zone = local.hosted_zone_with_records
   tags        = var.tags
 }

--- a/domains/infrastructure/front_door.tf
+++ b/domains/infrastructure/front_door.tf
@@ -4,4 +4,6 @@ resource "azurerm_cdn_frontdoor_profile" "main" {
   resource_group_name = each.value.resource_group_name
   sku_name            = "Standard_AzureFrontDoor"
   tags                = var.tags
+
+  lifecycle { ignore_changes = [tags] }
 }

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -7,7 +7,9 @@ variable "deploy_default_records" {
   default = true
 }
 
-variable "tags" {}
+variable "tags" {
+  default = null
+}
 
 locals {
   default_records = {


### PR DESCRIPTION
## What
tags are set at subscription and resource group levels. They are applied to individual resources automatically so there is no need to specify them.

## How to review
- Call the module with ref=448-make-domain-tags-optional
- Remove the tags argument