### PR TITLE
Improve Azure DNS controlled AKS migration

### DIFF
--- a/domains/environment_domains/dns.tf
+++ b/domains/environment_domains/dns.tf
@@ -29,7 +29,7 @@ resource "azurerm_dns_txt_record" "apex" {
 
 resource "azurerm_dns_cname_record" "main" {
   depends_on = [azurerm_cdn_frontdoor_route.main]
-  for_each   = { for k in toset(var.domains) : k => k if k != "apex" }
+  for_each   = { for k in toset(var.domains) : k => k if !contains(concat(["apex"], var.exclude_cnames), k) }
 
   name                = each.key
   zone_name           = data.azurerm_dns_zone.main.name

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -37,6 +37,7 @@ No modules.
 | <a name="input_cached_paths"></a> [cached\_paths](#input\_cached\_paths) | List of path patterns such as /packs/* that front door will cache | `list(string)` | `[]` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | n/a | `any` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `any` | n/a | yes |
+| <a name="input_exclude_cnames"></a> [exclude\_cnames](#input\_exclude\_cnames) | Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration. | `list` | `[]` | no |
 | <a name="input_front_door_name"></a> [front\_door\_name](#input\_front\_door\_name) | n/a | `any` | n/a | yes |
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
 | <a name="input_multiple_hosted_zones"></a> [multiple\_hosted\_zones](#input\_multiple\_hosted\_zones) | n/a | `bool` | `false` | no |

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -24,3 +24,8 @@ variable "cached_paths" {
   default     = []
   description = "List of path patterns such as /packs/* that front door will cache"
 }
+
+variable "exclude_cnames" {
+  default     = []
+  description = "Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration."
+}


### PR DESCRIPTION
### Context

At present if we manage the CNAME for a GOV.UK PaaS application using DNS module and we are setting the parallel environment up for the same environment in AKS for example there might be some down time when we add the domain to the front door configuration. This is because there are various bits of setup required, certificate validation and deployments.

This change allows us to add the environment we are migrating e.g. staging, to the domains list and also to the new list `exclude_cnames` so that all the setup except updating the actual CNAME is completed.

To update the CNAME to finally point the environment to the front door endpoint that is already setup, we just remove it from the `exclude_cnames` list and the list of managed domains we pass to the DNS module.

### Changes proposed in this pull request

As well as excluding CNAME creation for `apex` domains, also include this for domains defined in the `exclude_cnames` list.

### Guidance for review

Add the domain you want to configuring using the `environment_domains` module to both the `domains` and `exclude_cnames` lists.
Ensure the new variable is passed to the `environment_domains` module using `exclude_cnames = try(each.value.exclude_cnames, [])`
It should deploy all the defined resources (approx. 6) except the `azurerm_dns_cname_record`. 

### Other

This change is non-breaking since excluding the list does not change the existing behaviour