### PR TITLE
Add a default probe path

### DIFF
--- a/aks/application/README.md
+++ b/aks/application/README.md
@@ -43,6 +43,52 @@ module "worker_application" {
 }
 ```
 
+### Health checks
+
+For web applications, the default `probe_path` is set to `/healthcheck`. The probe can be turned off by setting the variable to `null`.
+
+#### Rails
+
+A simple one-line health check for a Rails application can be added to the `routes.rb` file:
+
+```rb
+get "/healthcheck", to: proc { [200, {}, ['OK']] }
+```
+
+For more complex health checks, the [OkComputer Gem] provides some advanced functionality, for example:
+
+```rb
+OkComputer.mount_at = "healthcheck"
+
+OkComputer::Registry.register "database", OkComputer::ActiveRecordCheck.new
+```
+
+[OkComputer Gem]: https://github.com/sportngin/okcomputer/
+
+#### .NET
+
+A simple one-line health check for an ASP.NET application can be added to the endpoints:
+
+```cs
+endpoints.MapGet("/healthcheck", async context => {
+    await context.Response.WriteAsync("OK");
+});
+```
+
+For more complex health checks, the [ASP.NET Core Health Checks Middleware] can be used, for example:
+
+```cs
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHealthChecks();
+
+var app = builder.Build();
+
+app.MapHealthChecks("/healthcheck/all");
+```
+
+[ASP.NET Core Health Checks Middleware]: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-7.0
+
 ## Outputs
 
 ### `hostname`

--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -1,7 +1,10 @@
 locals {
   name_suffix = var.name != null ? "-${var.name}" : ""
+  app_name    = "${var.service_name}-${var.environment}${local.name_suffix}"
 
-  app_name = "${var.service_name}-${var.environment}${local.name_suffix}"
+  http_probe_enabled = var.is_web && var.probe_path != null
+  exec_probe_enabled = !var.is_web && length(var.probe_command) != 0
+  probe_enabled      = local.http_probe_enabled || local.exec_probe_enabled
 }
 
 resource "kubernetes_deployment" "main" {

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the application | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
 | <a name="input_probe_command"></a> [probe\_command](#input\_probe\_command) | Command for the liveness and startup probe | `list(string)` | `[]` | no |
-| <a name="input_probe_path"></a> [probe\_path](#input\_probe\_path) | Path for the liveness and startup probe | `string` | `null` | no |
+| <a name="input_probe_path"></a> [probe\_path](#input\_probe\_path) | Path for the liveness and startup probe. The probe can be disabled by setting this to null. | `string` | `"/healthcheck"` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of application instances | `number` | `1` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_web_external_hostnames"></a> [web\_external\_hostnames](#input\_web\_external\_hostnames) | List of external hostnames for the web application | `list(string)` | `[]` | no |

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -82,8 +82,8 @@ variable "web_port" {
 
 variable "probe_path" {
   type        = string
-  default     = null
-  description = "Path for the liveness and startup probe"
+  default     = "/healthcheck"
+  description = "Path for the liveness and startup probe. The probe can be disabled by setting this to null."
 }
 
 variable "probe_command" {

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -92,8 +92,3 @@ variable "probe_command" {
   description = "Command for the liveness and startup probe"
 }
 
-locals {
-  http_probe_enabled = var.is_web && var.probe_path != null
-  exec_probe_enabled = !var.is_web && length(var.probe_command) != 0
-  probe_enabled      = local.http_probe_enabled || local.exec_probe_enabled
-}


### PR DESCRIPTION
This adds a default probe path for applications, setting it to `/healthcheck`. It can be disabled by setting the `probe_path` variable to `null`.

I've extracted the two commits from #33 which added this that were reverted by accident in #39.