### PR TITLE
409 front door logging

### DIFF
--- a/domains/infrastructure/diagnostics.md
+++ b/domains/infrastructure/diagnostics.md
@@ -1,0 +1,18 @@
+# Azure Front Door Diagnostics Log Query
+
+The script filters logs for client requests that returned HTTP status codes of 400 or above, groups these error requests by the host, path, HTTP status code, and resource ID, and then counts them.
+
+## KQL Script
+
+- run the script below or choose one of the auto generated ones from {frontdoor-name}-> logs -> query editor
+- once enabled this diagnostis will be set against the frontdoor which sin with in our production subscription
+
+
+```kql
+AzureDiagnostics
+| where ResourceProvider == "MICROSOFT.NETWORK" and Category == "FrontdoorAccessLog"
+| where isReceivedFromClient_b == true
+| where toint(httpStatusCode_s) >= 400
+| extend ParsedUrl = parseurl(requestUri_s)
+| summarize RequestCount = count() by Host = tostring(ParsedUrl.Host), Path = tostring(ParsedUrl.Path), StatusCode = httpStatusCode_s, ResourceId
+| order by RequestCount desc

--- a/domains/infrastructure/front_door.tf
+++ b/domains/infrastructure/front_door.tf
@@ -5,3 +5,33 @@ resource "azurerm_cdn_frontdoor_profile" "main" {
   sku_name            = "Standard_AzureFrontDoor"
   tags                = var.tags
 }
+
+data "azurerm_monitor_diagnostic_categories" "main" {
+  for_each = var.azure_enable_monitoring ? var.hosted_zone : {}
+
+  resource_id = azurerm_cdn_frontdoor_profile.main[each.key].id
+}
+
+resource "azurerm_monitor_diagnostic_setting" "main" {
+  for_each = var.azure_enable_monitoring ? var.hosted_zone : {}
+
+  name                       = "${each.value.front_door_name}-diagnostics"
+  target_resource_id         = azurerm_cdn_frontdoor_profile.main[each.key].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main[each.key].id
+
+  dynamic "enabled_log" {
+    for_each = data.azurerm_monitor_diagnostic_categories.main[each.key].log_category_types
+    content {
+      category = enabled_log.value
+    }
+  }
+}
+
+resource "azurerm_log_analytics_workspace" "main" {
+  for_each = var.azure_enable_monitoring ? var.hosted_zone : {}
+
+  name                = "${each.value.front_door_name}-log"
+  location            = "uksouth"
+  resource_group_name = each.value.resource_group_name
+  sku                 = "PerGB2018"
+}

--- a/domains/infrastructure/tfdocs.md
+++ b/domains/infrastructure/tfdocs.md
@@ -19,11 +19,15 @@ No requirements.
 | Name | Type |
 |------|------|
 | [azurerm_cdn_frontdoor_profile.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_profile) | resource |
+| [azurerm_log_analytics_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_diagnostic_categories.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | Enable monitoring and logging in Azure | `bool` | n/a | yes |
 | <a name="input_deploy_default_records"></a> [deploy\_default\_records](#input\_deploy\_default\_records) | n/a | `bool` | `true` | no |
 | <a name="input_hosted_zone"></a> [hosted\_zone](#input\_hosted\_zone) | n/a | `map(any)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -32,3 +32,8 @@ locals {
     zone_name => merge(zone_cfg, var.deploy_default_records ? local.default_records : null)
   }
 }
+
+variable "azure_enable_monitoring" {
+  type        = bool
+  description = "Enable monitoring and logging in Azure"
+}


### PR DESCRIPTION
Enable logging for Front Door using the Diagnostics settings 
Create a log analytics workspace 

**Testing** 

- You will require PIM as all the Front Doors are in prod, deploy your own front door or use TSC front door in dev  

- In order to test this set the module source to ```ref=409-front-door-logging```
-  run ```make register domains-infra-apply  ``` (example targets register app)


