### PR TITLE
Specify limits on provider versions

### DIFF
--- a/aks/application/terraform.tf
+++ b/aks/application/terraform.tf
@@ -1,15 +1,15 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.53"
+      version = "~> 3.53"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = "~> 2.20"
     }
   }
 }

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -2,15 +2,15 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.53 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.20 |
 
 ## Modules
 

--- a/aks/application_configuration/terraform.tf
+++ b/aks/application_configuration/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = "~> 2.20"
     }
   }
 }

--- a/aks/application_configuration/tfdocs.md
+++ b/aks/application_configuration/tfdocs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.20 |
 
 ## Modules
 

--- a/aks/cluster_data/terraform.tf
+++ b/aks/cluster_data/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.53"
+      version = "~> 3.53"
     }
   }
 }

--- a/aks/cluster_data/tfdocs.md
+++ b/aks/cluster_data/tfdocs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.53 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.53 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/aks/postgres/terraform.tf
+++ b/aks/postgres/terraform.tf
@@ -1,15 +1,15 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.53"
+      version = "~> 3.53"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = "~> 2.20"
     }
   }
 }

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -2,16 +2,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.53 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.53 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.20 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules

--- a/aks/redis/terraform.tf
+++ b/aks/redis/terraform.tf
@@ -1,15 +1,15 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.53"
+      version = "~> 3.53"
     }
 
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.20"
+      version = "~> 2.20"
     }
   }
 }

--- a/aks/redis/tfdocs.md
+++ b/aks/redis/tfdocs.md
@@ -2,16 +2,16 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.53 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.20 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.53 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.20 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.20 |
 
 ## Modules
 

--- a/aks/secrets/terraform.tf
+++ b/aks/secrets/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.53"
+      version = "~> 3.53"
     }
   }
 }

--- a/aks/secrets/tfdocs.md
+++ b/aks/secrets/tfdocs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.53 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.53 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/dns/records/terraform.tf
+++ b/dns/records/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.53"
+    }
+  }
+}

--- a/dns/records/tfdocs.md
+++ b/dns/records/tfdocs.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/dns/zones/terraform.tf
+++ b/dns/zones/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.53"
+    }
+  }
+}

--- a/dns/zones/tfdocs.md
+++ b/dns/zones/tfdocs.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/domains/environment_domains/terraform.tf
+++ b/domains/environment_domains/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.53"
+    }
+  }
+}

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/domains/infrastructure/terraform.tf
+++ b/domains/infrastructure/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.53"
+    }
+  }
+}

--- a/domains/infrastructure/tfdocs.md
+++ b/domains/infrastructure/tfdocs.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.53 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.53 |
 
 ## Modules
 

--- a/monitoring/statuscake/terraform.tf
+++ b/monitoring/statuscake/terraform.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = "~> 1.4"
 
   required_providers {
     statuscake = {
       source  = "StatusCakeDev/statuscake"
-      version = ">= 2.1"
+      version = "~> 2.1"
     }
   }
 }

--- a/monitoring/statuscake/tfdocs.md
+++ b/monitoring/statuscake/tfdocs.md
@@ -2,14 +2,14 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | >= 2.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
+| <a name="requirement_statuscake"></a> [statuscake](#requirement\_statuscake) | ~> 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_statuscake"></a> [statuscake](#provider\_statuscake) | >= 2.1 |
+| <a name="provider_statuscake"></a> [statuscake](#provider\_statuscake) | ~> 2.1 |
 
 ## Modules
 


### PR DESCRIPTION
Using the `~>` operator means the minor version will stay up to date, but avoids us upgrading the major version which may have breaking changes.