### PR TITLE
Specify StatusCake provider

### DIFF
--- a/monitoring/statuscake/terraform.tf
+++ b/monitoring/statuscake/terraform.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    statuscake = {
+      source = "StatusCakeDev/statuscake"
+    }
+  }
+}

--- a/monitoring/statuscake/tfdocs.md
+++ b/monitoring/statuscake/tfdocs.md
@@ -16,8 +16,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [statuscake_ssl_check.main](https://registry.terraform.io/providers/hashicorp/statuscake/latest/docs/resources/ssl_check) | resource |
-| [statuscake_uptime_check.main](https://registry.terraform.io/providers/hashicorp/statuscake/latest/docs/resources/uptime_check) | resource |
+| [statuscake_ssl_check.main](https://registry.terraform.io/providers/StatusCakeDev/statuscake/latest/docs/resources/ssl_check) | resource |
+| [statuscake_uptime_check.main](https://registry.terraform.io/providers/StatusCakeDev/statuscake/latest/docs/resources/uptime_check) | resource |
 
 ## Inputs
 


### PR DESCRIPTION
We need to specify the provider explicitly as Terraform can't guess the name as it's not in the `hashicorp` group. This should fix the following error:

```
Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/statuscake: provider registry registry.terraform.io does not
│ have a provider named registry.terraform.io/hashicorp/statuscake
│
│ Did you intend to use statuscakedev/statuscake? If so, you must specify that source address in each module which requires that provider.
│ To see which modules are currently depending on hashicorp/statuscake, run the following command:
│     terraform providers
╵
```

[Trello Card](https://trello.com/c/kKrwyzOE/488-bug-error-failed-to-query-available-provider-packages)