### PR TITLE
[506] Output postgres server id

### DIFF
--- a/aks/postgres/README.md
+++ b/aks/postgres/README.md
@@ -69,3 +69,7 @@ The name of the storage account that can be used to store backups.
 ### `azure_backup_storage_container_name`
 
 The name of the storage container that can be used to store backups.
+
+### `azure_server_id`
+
+ID of the database server in terraform. It can be used to create more databases in the same server (only available when using Azure postgres).

--- a/aks/postgres/outputs.tf
+++ b/aks/postgres/outputs.tf
@@ -42,3 +42,7 @@ output "azure_backup_storage_account_name" {
 output "azure_backup_storage_container_name" {
   value = local.azure_enable_backup_storage ? azurerm_storage_container.backup[0].name : null
 }
+
+output "azure_server_id" {
+  value = var.use_azure ? azurerm_postgresql_flexible_server.main[0].id : null
+}

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -74,6 +74,7 @@ No modules.
 |------|-------------|
 | <a name="output_azure_backup_storage_account_name"></a> [azure\_backup\_storage\_account\_name](#output\_azure\_backup\_storage\_account\_name) | n/a |
 | <a name="output_azure_backup_storage_container_name"></a> [azure\_backup\_storage\_container\_name](#output\_azure\_backup\_storage\_container\_name) | n/a |
+| <a name="output_azure_server_id"></a> [azure\_server\_id](#output\_azure\_server\_id) | n/a |
 | <a name="output_dotnet_connection_string"></a> [dotnet\_connection\_string](#output\_dotnet\_connection\_string) | n/a |
 | <a name="output_host"></a> [host](#output\_host) | n/a |
 | <a name="output_name"></a> [name](#output\_name) | n/a |


### PR DESCRIPTION
## What
Add `server_id` output to the postgres module. It can be used to create more resources depending on the database server outside of the module, like new databases.