### PR TITLE
[548] Make azure_enable_monitoring optional

### DIFF
--- a/domains/infrastructure/tfdocs.md
+++ b/domains/infrastructure/tfdocs.md
@@ -27,7 +27,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | Enable monitoring and logging in Azure | `bool` | n/a | yes |
+| <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | Enable monitoring and logging in Azure | `bool` | `false` | no |
 | <a name="input_deploy_default_records"></a> [deploy\_default\_records](#input\_deploy\_default\_records) | n/a | `bool` | `true` | no |
 | <a name="input_hosted_zone"></a> [hosted\_zone](#input\_hosted\_zone) | n/a | `map(any)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | `null` | no |

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -11,6 +11,13 @@ variable "tags" {
   default = null
 }
 
+variable "azure_enable_monitoring" {
+  type        = bool
+  description = "Enable monitoring and logging in Azure"
+  default     = false
+}
+
+
 locals {
   default_records = {
     "caa_records" = {
@@ -33,9 +40,4 @@ locals {
   hosted_zone_with_records = { for zone_name, zone_cfg in var.hosted_zone :
     zone_name => merge(zone_cfg, var.deploy_default_records ? local.default_records : null)
   }
-}
-
-variable "azure_enable_monitoring" {
-  type        = bool
-  description = "Enable monitoring and logging in Azure"
 }


### PR DESCRIPTION
## What
The variable was introduced without a default value and it breaks deployments which don't use it. Now defauts to false as it's the previous behaviour.

## How to review
Before change: https://github.com/DFE-Digital/teacher-services-cloud/actions/runs/5764673062/job/15629135387
After change: https://github.com/DFE-Digital/teacher-services-cloud/actions/runs/5783519228/job/15672451667