### PR TITLE
[450] Set production cpu_min to 0.8

### DIFF
--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -65,7 +65,7 @@ locals {
       resource_group_name = "s189p01-tsc-pd-rg"
       resource_prefix     = "s189p01-tsc-production"
       dns_zone_prefix     = null
-      cpu_min             = 1
+      cpu_min             = 0.8
     }
   }
 


### PR DESCRIPTION
## What
Allow at least one more of our app processes and use use more of the memory

## How to review
We are maxing out CPU and use little memory:

```
kubectl describe nodes -l agentpool=apps1 | egrep -e '^Name|memory|cpu' | egrep -e 'Name|%'
Name:               aks-apps1-29533562-vmss00006d
  cpu                3660m (94%)      4600m (119%)
  memory             8283172Ki (29%)  11023396Ki (38%)
Name:               aks-apps1-29533562-vmss00007z
  cpu                3560m (92%)   4500m (116%)
  memory             3932Mi (14%)  6608Mi (23%)
...
```

On a typical node with 4 cores, we have 3 app processes we deployed, totalling 3000m CPU. And some system processes using around 600m.
Today with request = 1
3 * 1000 = 3000m
rest = 600m
3000 + 600 = 3600m

With request = 800m
3 * 800m = 2400m
rest = 600m
2400 + 600 = 3000m
This would allow deploying 1 more app process and use more of the available memory. There is a risk of over committing CPU if all processes are heavily used at the same time. But since we have many different services now, it's unlikely they will have the same high usage at the same time.