### PR TITLE
[574] cluster_data ingress_domain output

### DIFF
--- a/aks/cluster_data/README.md
+++ b/aks/cluster_data/README.md
@@ -48,3 +48,12 @@ The client key to use to connect to the Kubernetes cluster.
 ### `kubenetes_cluster_ca_certificate`
 
 The client cluster CA certificate to use to connect to the Kubernetes cluster.
+
+### `ingress_domain`
+
+Generic domain for all web applications on the cluster.
+
+For example the test cluster ingress domain is "test.teacherservices.cloud". The web application apply-review-1234 full domain is:
+
+`<app name>.<ingress domain>` or
+"apply-review-1234.test.teacherservices.cloud"

--- a/aks/cluster_data/outputs.tf
+++ b/aks/cluster_data/outputs.tf
@@ -17,3 +17,7 @@ output "kubernetes_client_key" {
 output "kubernetes_cluster_ca_certificate" {
   value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.cluster_ca_certificate)
 }
+
+output "ingress_domain" {
+  value = "${local.dns_zone_prefix_with_optional_dot}teacherservices.cloud"
+}

--- a/aks/cluster_data/tfdocs.md
+++ b/aks/cluster_data/tfdocs.md
@@ -29,6 +29,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_configuration_map"></a> [configuration\_map](#output\_configuration\_map) | n/a |
+| <a name="output_ingress_domain"></a> [ingress\_domain](#output\_ingress\_domain) | n/a |
 | <a name="output_kubernetes_client_certificate"></a> [kubernetes\_client\_certificate](#output\_kubernetes\_client\_certificate) | n/a |
 | <a name="output_kubernetes_client_key"></a> [kubernetes\_client\_key](#output\_kubernetes\_client\_key) | n/a |
 | <a name="output_kubernetes_cluster_ca_certificate"></a> [kubernetes\_cluster\_ca\_certificate](#output\_kubernetes\_cluster\_ca\_certificate) | n/a |

--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -69,5 +69,6 @@ locals {
     }
   }
 
-  configuration_map = local.configuration_maps[var.name]
+  configuration_map                 = local.configuration_maps[var.name]
+  dns_zone_prefix_with_optional_dot = local.configuration_map.dns_zone_prefix == null ? "" : "${local.configuration_map.dns_zone_prefix}."
 }


### PR DESCRIPTION
## What
Add new output to cluster_data. Useful output to determine the full web application domain on any cluster

## How to review
Use module.cluster_data.ingress_domain on an existing deployment