### PR TITLE
[633] Increase redis timeout from 30m to 1h

### DIFF
--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -30,8 +30,8 @@ resource "azurerm_redis_cache" "main" {
   }
 
   timeouts {
-    create = "30m"
-    update = "30m"
+    create = "1h"
+    update = "1h"
   }
 
   lifecycle {


### PR DESCRIPTION
## What
Azure redis creation is very slow at the moment and frequently fails. This should solve most issues as it takes about 30-45min.