### PR TITLE
Provide docker image for database in kubernetes deployment as variable

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -252,7 +252,7 @@ resource "kubernetes_deployment" "main" {
         }
         container {
           name  = local.kubernetes_name
-          image = "postgres:${var.server_version}-alpine"
+          image = var.server_docker_image
           resources {
             requests = {
               cpu    = var.cluster_configuration_map.cpu_min

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -63,6 +63,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
+| <a name="input_server_docker_image"></a> [server\_docker\_image](#input\_server\_docker\_image) | Database image to use with kubernetes deployment, eg. postgis/postgis:14-3.4 | `string` | `"postgres:14-alpine"` | no |
 | <a name="input_server_version"></a> [server\_version](#input\_server\_version) | Version of PostgreSQL server | `string` | `"14"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -44,6 +44,12 @@ variable "cluster_configuration_map" {
   description = "Configuration map for the cluster"
 }
 
+variable "server_docker_image" {
+  type        = string
+  default     = "postgres:14-alpine"
+  description = "Database image to use with kubernetes deployment, eg. postgis/postgis:14-3.4"
+}
+
 variable "server_version" {
   type        = string
   default     = "14"


### PR DESCRIPTION
Some extensions, in my case `postgis`, do not work on the official Postgres docker image. In order to use it, I introduced a new variable to make the image configurable.