### PR TITLE
Allow apex domains from multiple zones

### DIFF
--- a/domains/environment_domains/dns.tf
+++ b/domains/environment_domains/dns.tf
@@ -4,7 +4,7 @@ data "azurerm_dns_zone" "main" {
 }
 
 resource "azurerm_dns_txt_record" "main" {
-  for_each            = { for k in toset(var.domains) : k => k if k != "apex" }
+  for_each            = { for k in toset(var.domains) : k => k if !startswith(k, "apex") }
   name                = join(".", ["_dnsauth", "${each.key}"])
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
@@ -16,7 +16,7 @@ resource "azurerm_dns_txt_record" "main" {
 }
 
 resource "azurerm_dns_txt_record" "apex" {
-  for_each            = { for k in toset(var.domains) : k => k if k == "apex" }
+  for_each            = { for k in toset(var.domains) : k => k if startswith(k, "apex") }
   name                = "_dnsauth"
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
@@ -27,9 +27,10 @@ resource "azurerm_dns_txt_record" "apex" {
   }
 }
 
+# We create the CNAME record if it's not excluded and if it's not an apex
 resource "azurerm_dns_cname_record" "main" {
   depends_on = [azurerm_cdn_frontdoor_route.main]
-  for_each   = { for k in toset(var.domains) : k => k if !contains(concat(["apex"], var.exclude_cnames), k) }
+  for_each   = { for k in toset(var.domains) : k => k if !contains(var.exclude_cnames, k) && !startswith(k, "apex") }
 
   name                = each.key
   zone_name           = data.azurerm_dns_zone.main.name
@@ -40,7 +41,7 @@ resource "azurerm_dns_cname_record" "main" {
 
 resource "azurerm_dns_a_record" "main" {
   depends_on          = [azurerm_cdn_frontdoor_route.main]
-  for_each            = { for k in toset(var.domains) : k => k if k == "apex" }
+  for_each            = { for k in toset(var.domains) : k => k if startswith(k, "apex") }
   name                = "@"
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -36,7 +36,7 @@ resource "azurerm_cdn_frontdoor_custom_domain" "main" {
   name                     = replace(each.key, ".", "-")
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
   dns_zone_id              = data.azurerm_dns_zone.main.id
-  host_name                = each.key == "apex" ? "${var.zone}" : "${each.key}.${var.zone}"
+  host_name                = startswith(each.key, "apex") ? "${var.zone}" : "${each.key}.${var.zone}"
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"

--- a/domains/environment_domains/front_door_rules.tf
+++ b/domains/environment_domains/front_door_rules.tf
@@ -17,7 +17,7 @@ resource "azurerm_cdn_frontdoor_rule" "rule" {
   conditions {
     host_name_condition {
       operator     = "Equal"
-      match_values = [for d in [var.redirect_rules[count.index]["from-domain"]] : d == "apex" ? "${var.zone}" : "${d}.${var.zone}"]
+      match_values = [for d in [var.redirect_rules[count.index]["from-domain"]] : startswith(d, "apex") ? "${var.zone}" : "${d}.${var.zone}"]
     }
   }
 

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -37,7 +37,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cached_paths"></a> [cached\_paths](#input\_cached\_paths) | List of path patterns such as /packs/* that front door will cache | `list(string)` | `[]` | no |
-| <a name="input_domains"></a> [domains](#input\_domains) | n/a | `any` | n/a | yes |
+| <a name="input_domains"></a> [domains](#input\_domains) | List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use | `any` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `any` | n/a | yes |
 | <a name="input_exclude_cnames"></a> [exclude\_cnames](#input\_exclude\_cnames) | Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration. | `list` | `[]` | no |
 | <a name="input_front_door_name"></a> [front\_door\_name](#input\_front\_door\_name) | n/a | `any` | n/a | yes |

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -1,7 +1,11 @@
 variable "zone" {}
 variable "front_door_name" {}
 variable "resource_group_name" {}
-variable "domains" {}
+variable "domains" {
+  description = <<EOF
+    List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use
+  EOF
+}
 variable "environment" {}
 variable "host_name" {
   default     = "not-in-use.education.gov.uk"


### PR DESCRIPTION
We want to use frontdoor for multiple dns zones with each one having its own apex. Update the apex condition to allow apex, apex<Something>...

## Changes proposed in this pull request
Update Frontdoor and Frontdoor rules


## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
