### PR TITLE
[792] Override statuscake confirmations

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -3,7 +3,7 @@ resource "statuscake_uptime_check" "main" {
 
   name           = each.value
   contact_groups = var.contact_groups
-  confirmation   = 2
+  confirmation   = var.confirmation
   trigger_rate   = 0
   check_interval = 30
   regions        = ["london", "dublin"]

--- a/monitoring/statuscake/tfdocs.md
+++ b/monitoring/statuscake/tfdocs.md
@@ -23,6 +23,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_confirmation"></a> [confirmation](#input\_confirmation) | Retry the check when an error is detected to avoid false positives and micro downtimes | `number` | `2` | no |
 | <a name="input_contact_groups"></a> [contact\_groups](#input\_contact\_groups) | Contact groups for the alerts | `list(string)` | `[]` | no |
 | <a name="input_ssl_urls"></a> [ssl\_urls](#input\_ssl\_urls) | Set of URLs to perform SSL checks on | `list(string)` | `[]` | no |
 | <a name="input_uptime_urls"></a> [uptime\_urls](#input\_uptime\_urls) | Set of URLs to perform uptime checks on | `list(string)` | `[]` | no |

--- a/monitoring/statuscake/variables.tf
+++ b/monitoring/statuscake/variables.tf
@@ -15,3 +15,9 @@ variable "contact_groups" {
   description = "Contact groups for the alerts"
   default     = []
 }
+
+variable "confirmation" {
+  type        = number
+  description = "Retry the check when an error is detected to avoid false positives and micro downtimes"
+  default     = 2
+}


### PR DESCRIPTION
## Context
We want to be able to detect front door SSL errors using statuscake, but the default 2 confirmations may hide them.

## Changes proposed in this pull request
Add a new "confirmation" variable to override it, but keep the default value as 2.

## Guidance to review
In a repo using statuscake, point terrafile to this branch and test adding confirmation.

Example in teaching-record-system:
```
...
  # module.statuscake[0].statuscake_uptime_check.main["https://trs-production-ui.teacherservices.cloud/health"] will be updated in-place
  ~ resource "statuscake_uptime_check" "main" {
      ~ confirmation   = 2 -> 0
        id             = "6932525"
        name           = "https://trs-production-ui.teacherservices.cloud/health"
        tags           = []
        # (6 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 3 to change, 0 to destroy.
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
