### PR TITLE
Make terraform module variables nullable

### DIFF
--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -37,6 +37,7 @@ variable "cluster_configuration_map" {
 
 variable "replicas" {
   type        = number
+  nullable    = false
   default     = 1
   description = "Number of application instances"
 }
@@ -64,42 +65,49 @@ variable "docker_image" {
 
 variable "command" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = "Custom command that overwrites Docker image"
 }
 
 variable "max_memory" {
   type        = string
+  nullable    = false
   default     = "1Gi"
   description = "Maximum memory of the instance"
 }
 
 variable "is_web" {
   type        = bool
+  nullable    = false
   default     = true
   description = "Whether this a web application"
 }
 
 variable "web_external_hostnames" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = "List of external hostnames for the web application"
 }
 
 variable "web_port" {
   type        = number
+  nullable    = false
   default     = 3000
   description = "Port of the web application"
 }
 
 variable "probe_path" {
   type        = string
+  nullable    = false
   default     = "/healthcheck"
   description = "Path for the liveness and startup probe. The probe can be disabled by setting this to null."
 }
 
 variable "probe_command" {
   type        = list(string)
+  nullable    = false
   default     = []
   description = "Command for the liveness and startup probe"
 }
@@ -123,6 +131,7 @@ variable "azure_resource_prefix" {
 
 variable "azure_enable_monitoring" {
   type        = bool
+  nullable    = false
   default     = false
   description = "Whether to enable monitoring of container failures"
 }

--- a/aks/application_configuration/variables.tf
+++ b/aks/application_configuration/variables.tf
@@ -25,12 +25,14 @@ variable "config_short" {
 
 variable "is_rails_application" {
   type        = bool
+  nullable    = false
   default     = false
   description = "If true, sets config variables for a Rails application"
 }
 
 variable "config_variables" {
   type        = map(string)
+  nullable    = false
   default     = {}
   description = "Additional configuration variables"
 }
@@ -55,6 +57,7 @@ variable "secret_yaml_key" {
 
 variable "secret_variables" {
   type        = map(string)
+  nullable    = false
   default     = {}
   description = "Additional secret variables"
 }

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -46,6 +46,7 @@ variable "cluster_configuration_map" {
 
 variable "server_docker_image" {
   type        = string
+  nullable    = false
   default     = "postgres:14-alpine"
   description = "Database image to use with kubernetes deployment, eg. postgis/postgis:14-3.4"
 }
@@ -85,13 +86,15 @@ variable "azure_sku_name" {
 }
 
 variable "azure_enable_high_availability" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 variable "azure_extensions" {
-  type    = list(string)
-  default = []
+  type     = list(string)
+  nullable = false
+  default  = []
 }
 
 variable "azure_memory_threshold" {
@@ -110,12 +113,14 @@ variable "azure_storage_threshold" {
 }
 
 variable "azure_enable_monitoring" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "alert_window_size" {
   type        = string
+  nullable    = false
   default     = "PT5M"
   description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
 }
@@ -130,6 +135,7 @@ variable "azure_maintenance_window" {
 }
 
 variable "azure_enable_backup_storage" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }

--- a/aks/redis/variables.tf
+++ b/aks/redis/variables.tf
@@ -46,6 +46,7 @@ variable "cluster_configuration_map" {
 
 variable "server_version" {
   type        = string
+  nullable    = false
   default     = "6"
   description = "Version of Redis server"
 }
@@ -71,13 +72,15 @@ variable "azure_sku_name" {
 }
 
 variable "azure_minimum_tls_version" {
-  type    = string
-  default = "1.2"
+  type     = string
+  nullable = false
+  default  = "1.2"
 }
 
 variable "azure_public_network_access_enabled" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 variable "azure_memory_threshold" {
@@ -86,13 +89,15 @@ variable "azure_memory_threshold" {
 }
 
 variable "azure_maxmemory_policy" {
-  type    = string
-  default = "allkeys-lru"
+  type     = string
+  nullable = false
+  default  = "allkeys-lru"
 }
 
 variable "azure_enable_monitoring" {
-  type    = bool
-  default = true
+  type     = bool
+  nullable = false
+  default  = true
 }
 
 variable "azure_patch_schedule" {
@@ -101,12 +106,14 @@ variable "azure_patch_schedule" {
     start_hour_utc     = optional(number),
     maintenance_window = optional(string)
   }))
-  default = []
+  nullable = false
+  default  = []
 }
 
 variable "alert_window_size" {
   type        = string
   default     = "PT5M"
+  nullable    = false
   description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
 }
 

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -13,18 +13,21 @@ variable "host_name" {
 }
 
 variable "null_host_header" {
+  nullable    = false
   default     = false
   description = "The origin_host_header for the azurerm_cdn_frontdoor_origin resource will be var.host_name (if false) or null (if true). If null then the host name from the incoming request will be used."
 }
 
 variable "rule_set_ids" {
-  type    = list(any)
-  default = []
+  type     = list(any)
+  nullable = false
+  default  = []
 }
 
 variable "multiple_hosted_zones" {
-  type    = bool
-  default = false
+  type     = bool
+  nullable = false
+  default  = false
 }
 
 variable "cached_paths" {
@@ -34,11 +37,13 @@ variable "cached_paths" {
 }
 
 variable "exclude_cnames" {
+  nullable    = false
   default     = []
   description = "Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration."
 }
 
 variable "redirect_rules" {
+  nullable    = false
   default     = {}
   description = <<EOF
     List of ordered redirect rules with format:

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -3,8 +3,9 @@ variable "hosted_zone" {
 }
 
 variable "deploy_default_records" {
-  type    = bool
-  default = true
+  nullable = false
+  type     = bool
+  default  = true
 }
 
 variable "tags" {
@@ -12,6 +13,7 @@ variable "tags" {
 }
 
 variable "azure_enable_monitoring" {
+  nullable    = false
   type        = bool
   description = "Enable monitoring and logging in Azure"
   default     = false

--- a/monitoring/statuscake/variables.tf
+++ b/monitoring/statuscake/variables.tf
@@ -1,23 +1,27 @@
 variable "uptime_urls" {
   type        = list(string)
+  nullable    = false
   description = "Set of URLs to perform uptime checks on"
   default     = []
 }
 
 variable "ssl_urls" {
   type        = list(string)
+  nullable    = false
   description = "Set of URLs to perform SSL checks on"
   default     = []
 }
 
 variable "contact_groups" {
   type        = list(string)
+  nullable    = false
   description = "Contact groups for the alerts"
   default     = []
 }
 
 variable "confirmation" {
   type        = number
+  nullable    = false
   description = "Retry the check when an error is detected to avoid false positives and micro downtimes"
   default     = 2
 }


### PR DESCRIPTION

## Context
So we can have the option of leaving some parameters empty and they pick the default value or we override the default other values when we use the modules

## Changes proposed in this pull request
Make terraform module variables nullable if they are optional and have default values(and the default value isn't null)


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
