### PR TITLE
Update CAA record to globalsign and digicert

### DIFF
--- a/dns/Readme.md
+++ b/dns/Readme.md
@@ -61,7 +61,7 @@ So we add the following 3 records to indicate we don't send mail from these doma
 
 - CAA record
 ```
-0 issue "amazon.com"
+0 issue "globalsign.com"
 ```
 
 # Records
@@ -82,7 +82,7 @@ To create (or update) records to an existing zone
 - Run the make command with DNS_ENV set to the environment you are adding records too
 
     - make ${zone} dnsrecord-plan DNS_ENV=${env}
-    - make ${zone} dnsrecord-apply DNS_ENV=$env}
+    - make ${zone} dnsrecord-apply DNS_ENV=${env}
         - e.g. make register dnsrecord-plan DNS_ENV=qa
 
 Note;

--- a/dns/zones/resources.tf
+++ b/dns/zones/resources.tf
@@ -14,9 +14,10 @@ resource "azurerm_dns_zone" "dns_zone" {
 # CAA record
 
 locals {
+  # caa_records is deprecated. Use caa_record_list instead
   caa_records = flatten([
     for zone_name, zone_cfg in var.hosted_zone : [
-      for record_name, record_cfg in zone_cfg["caa_records"] : {
+      for record_name, record_cfg in try(zone_cfg["caa_records"], {}) : {
         record_name         = record_name
         zone_name           = zone_name
         resource_group_name = zone_cfg["resource_group_name"]
@@ -26,8 +27,15 @@ locals {
       }
     ]
   ])
+
+  hosted_zone_with_caa_record_list = {
+    for zone_name, zone_cfg in var.hosted_zone :
+    zone_name => zone_cfg
+    if length(try(zone_cfg.caa_record_list, [])) > 0
+  }
 }
 
+# caa_records is deprecated. Use caa_record_list instead
 resource "azurerm_dns_caa_record" "caa_records" {
   for_each = {
     for zone in local.caa_records : "${zone.zone_name}.${zone.record_name}" => zone
@@ -42,6 +50,29 @@ resource "azurerm_dns_caa_record" "caa_records" {
     flags = each.value.flags
     tag   = each.value.tag
     value = each.value.value
+  }
+
+  depends_on = [
+    azurerm_dns_zone.dns_zone
+  ]
+
+}
+
+resource "azurerm_dns_caa_record" "caa_record_list" {
+  for_each = local.hosted_zone_with_caa_record_list
+
+  name                = "@"
+  zone_name           = each.key
+  resource_group_name = each.value.resource_group_name
+  ttl                 = 300
+
+  dynamic "record" {
+    for_each = toset(each.value.caa_record_list)
+    content {
+      flags = 0
+      tag   = "issue"
+      value = record.value
+    }
   }
 
   depends_on = [

--- a/dns/zones/tfdocs.md
+++ b/dns/zones/tfdocs.md
@@ -16,6 +16,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_dns_caa_record.caa_record_list](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_caa_record.caa_records](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_txt_record.txt_records](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
 | [azurerm_dns_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |

--- a/domains/infrastructure/variables.tf
+++ b/domains/infrastructure/variables.tf
@@ -22,13 +22,7 @@ variable "azure_enable_monitoring" {
 
 locals {
   default_records = {
-    "caa_records" = {
-      "@" = {
-        "flags" = 0,
-        "tag"   = "issue",
-        "value" = "digicert.com"
-      }
-    }
+    "caa_record_list" = ["globalsign.com", "digicert.com"],
     "txt_records" = {
       "@" = {
         "value" = "v=spf1 -all"


### PR DESCRIPTION
## Context
We need to change the certificate authority as the supplier has changed

## Changes proposed in this pull request
Update CAA record from digicert.com to both globalsign.com and digicert.com

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
