### PR TITLE
CPU min reduced to run more pods on node.

### DIFF
--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -51,7 +51,7 @@ locals {
       resource_group_name = "s189t01-tsc-ts-rg"
       resource_prefix     = "s189t01-tsc-test"
       dns_zone_prefix     = "test"
-      cpu_min             = 0.1
+      cpu_min             = 0.05
     }
 
     platform-test = {
@@ -65,7 +65,7 @@ locals {
       resource_group_name = "s189p01-tsc-pd-rg"
       resource_prefix     = "s189p01-tsc-production"
       dns_zone_prefix     = null
-      cpu_min             = 0.8
+      cpu_min             = 0.5
     }
   }
 


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
https://trello.com/c/UNWoI5f8/885-bug-deployments-are-timing-out-on-the-test-cluster

1 ) Test cluster double the number of pods per node.
2 ) Prod cluster 8 pods per node instead of 5.

## Changes proposed in this pull request
cpu_min  changed for both test and prod.
## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
