### PR TITLE
[925] Update cluster_data outputs for Azure RBAC

### DIFF
--- a/aks/cluster_data/README.md
+++ b/aks/cluster_data/README.md
@@ -43,15 +43,41 @@ The ID of the Kubernetes Managed Cluster.
 
 ### `kubernetes_client_certificate`
 
-The client certificate to use to connect to the Kubernetes cluster.
+The client certificate to use to connect to the Kubernetes cluster. `null` when the cluster uses Azure RBAC.
 
 ### `kubernetes_client_key`
 
-The client key to use to connect to the Kubernetes cluster.
+The client key to use to connect to the Kubernetes cluster. `null` when the cluster uses Azure RBAC.
 
 ### `kubenetes_cluster_ca_certificate`
 
 The client cluster CA certificate to use to connect to the Kubernetes cluster.
+
+### `azure_RBAC_enabled`
+
+`true` if the cluster uses Azure RBAC
+
+### `kubelogin_args`
+
+Arguments for [kubelogin](https://azure.github.io/kubelogin/) to authenticate to a cluster using Azure RBAC. Used in the kubernetes provider configuration:
+
+```hcl
+provider "kubernetes" {
+  host                   = module.cluster_data.kubernetes_host
+  client_certificate     = module.cluster_data.kubernetes_client_certificate
+  client_key             = module.cluster_data.kubernetes_client_key
+  cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
+}
+```
 
 ### `ingress_domain`
 

--- a/aks/cluster_data/data.tf
+++ b/aks/cluster_data/data.tf
@@ -2,3 +2,18 @@ data "azurerm_kubernetes_cluster" "main" {
   name                = "${local.configuration_map.resource_prefix}-aks"
   resource_group_name = local.configuration_map.resource_group_name
 }
+
+data "azurerm_client_config" "current" {}
+
+terraform {
+  required_providers {
+    environment = {
+      source  = "EppO/environment"
+      version = "1.3.5"
+    }
+  }
+}
+
+data "environment_variables" "github_actions" {
+  filter = "GITHUB_ACTIONS"
+}

--- a/aks/cluster_data/outputs.tf
+++ b/aks/cluster_data/outputs.tf
@@ -11,11 +11,15 @@ output "kubernetes_id" {
 }
 
 output "kubernetes_client_certificate" {
-  value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)
+  value = (local.azure_RBAC_enabled ? null :
+    base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_certificate)
+  )
 }
 
 output "kubernetes_client_key" {
-  value = base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_key)
+  value = (local.azure_RBAC_enabled ? null :
+    base64decode(data.azurerm_kubernetes_cluster.main.kube_config.0.client_key)
+  )
 }
 
 output "kubernetes_cluster_ca_certificate" {
@@ -24,4 +28,11 @@ output "kubernetes_cluster_ca_certificate" {
 
 output "ingress_domain" {
   value = "${local.dns_zone_prefix_with_optional_dot}teacherservices.cloud"
+}
+
+output "kubelogin_args" {
+  value = local.spn_authentication ? local.kubelogin_args_map["spn"] : local.kubelogin_args_map["azurecli"]
+}
+output "azure_RBAC_enabled" {
+  value = local.azure_RBAC_enabled
 }

--- a/aks/cluster_data/tfdocs.md
+++ b/aks/cluster_data/tfdocs.md
@@ -1,12 +1,15 @@
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_environment"></a> [environment](#requirement\_environment) | 1.3.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_environment"></a> [environment](#provider\_environment) | 1.3.5 |
 
 ## Modules
 
@@ -16,7 +19,9 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
+| [environment_variables.github_actions](https://registry.terraform.io/providers/EppO/environment/1.3.5/docs/data-sources/variables) | data source |
 
 ## Inputs
 
@@ -28,8 +33,10 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_azure_RBAC_enabled"></a> [azure\_RBAC\_enabled](#output\_azure\_RBAC\_enabled) | n/a |
 | <a name="output_configuration_map"></a> [configuration\_map](#output\_configuration\_map) | n/a |
 | <a name="output_ingress_domain"></a> [ingress\_domain](#output\_ingress\_domain) | n/a |
+| <a name="output_kubelogin_args"></a> [kubelogin\_args](#output\_kubelogin\_args) | n/a |
 | <a name="output_kubernetes_client_certificate"></a> [kubernetes\_client\_certificate](#output\_kubernetes\_client\_certificate) | n/a |
 | <a name="output_kubernetes_client_key"></a> [kubernetes\_client\_key](#output\_kubernetes\_client\_key) | n/a |
 | <a name="output_kubernetes_cluster_ca_certificate"></a> [kubernetes\_cluster\_ca\_certificate](#output\_kubernetes\_cluster\_ca\_certificate) | n/a |

--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -71,4 +71,29 @@ locals {
 
   configuration_map                 = local.configuration_maps[var.name]
   dns_zone_prefix_with_optional_dot = local.configuration_map.dns_zone_prefix == null ? "" : "${local.configuration_map.dns_zone_prefix}."
+
+  kubelogin_args_map = {
+    spn = [
+      "get-token",
+      "--login",
+      "spn",
+      "--environment",
+      "AzurePublicCloud",
+      "--tenant-id",
+      data.azurerm_client_config.current.tenant_id,
+      "--server-id",
+      "6dae42f8-4368-4678-94ff-3960e28e3630" # See https://azure.github.io/kubelogin/concepts/aks.html
+    ],
+    azurecli = [
+      "get-token",
+      "--login",
+      "azurecli",
+      "--server-id",
+      "6dae42f8-4368-4678-94ff-3960e28e3630"
+    ]
+  }
+
+  azure_RBAC_enabled = length(data.azurerm_kubernetes_cluster.main.azure_active_directory_role_based_access_control) > 0
+
+  spn_authentication = contains(keys(data.environment_variables.github_actions.items), "GITHUB_ACTIONS")
 }


### PR DESCRIPTION
## Context
Make it easier for apps to deploy to Azure RBAC enabled clusters

## Changes proposed in this pull request
Update cluster_data outputs and introduce the spn_authentication variable to choose between spn and azurecli authentication

## Guidance to review
See draft PR https://github.com/DFE-Digital/register-trainee-teachers/pull/3949

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
