### PR TITLE
[1609] Override postgres server name

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -3,8 +3,9 @@ locals {
 
   name_suffix = var.name != null ? "-${var.name}" : ""
 
-  azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}"
-  azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}-pe"
+  azure_generated_name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-pg${local.name_suffix}"
+  azure_name           = var.azure_name_override == null ? local.azure_generated_name : var.azure_name_override
+
   azure_enable_backup_storage = var.use_azure && var.azure_enable_backup_storage
   azure_enable_monitoring     = var.use_azure && var.azure_enable_monitoring
 

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_azure_extensions"></a> [azure\_extensions](#input\_azure\_extensions) | n/a | `list(string)` | `[]` | no |
 | <a name="input_azure_maintenance_window"></a> [azure\_maintenance\_window](#input\_azure\_maintenance\_window) | n/a | <pre>object({<br>    day_of_week  = optional(number)<br>    start_hour   = optional(number)<br>    start_minute = optional(number)<br>  })</pre> | `null` | no |
 | <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `75` | no |
+| <a name="input_azure_name_override"></a> [azure\_name\_override](#input\_azure\_name\_override) | Replace the generated name with hardcoded name | `string` | `null` | no |
 | <a name="input_azure_resource_prefix"></a> [azure\_resource\_prefix](#input\_azure\_resource\_prefix) | Prefix of Azure resources for the service | `string` | n/a | yes |
 | <a name="input_azure_sku_name"></a> [azure\_sku\_name](#input\_azure\_sku\_name) | n/a | `string` | `"B_Standard_B1ms"` | no |
 | <a name="input_azure_storage_mb"></a> [azure\_storage\_mb](#input\_azure\_storage\_mb) | n/a | `number` | `32768` | no |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -4,6 +4,12 @@ variable "name" {
   default     = null
 }
 
+variable "azure_name_override" {
+  type        = string
+  description = "Replace the generated name with hardcoded name"
+  default     = null
+}
+
 variable "namespace" {
   type        = string
   description = "Current namespace"


### PR DESCRIPTION
## Context
Required for migrating Apply for teacher training to terraform-modules without rebuilding the database

## Changes proposed in this pull request
Add variable azure_name_override

## Guidance to review
Run Apply for teacher training terraform from branch 1609-apply-for-tt-migrate-code-to-terraform-modules

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
