### PR TITLE
[1649] Validate SSL on uptime check

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -13,7 +13,7 @@ resource "statuscake_uptime_check" "main" {
     timeout          = 40
     request_method   = "HTTP"
     status_codes     = ["204", "205", "206", "303", "400", "401", "403", "404", "405", "406", "408", "410", "413", "444", "429", "494", "495", "496", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511", "521", "522", "523", "524", "520", "598", "599"]
-    validate_ssl     = false
+    validate_ssl     = true
   }
 
   monitored_resource {


### PR DESCRIPTION
## Context
We had an incident with a expired certificate and it took us hours to detect it. There was a Statuscake uptime check, but it did not show a problem with the website.

## Changes proposed in this pull request
Enable the "validate_ssl" option by default so it alerts when the certificate is expired.

## Guidance to review
- Run terraform on publish staging for example, using the branch for terrafile
- Observe the ssl setting is enabled

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
