### PR TITLE
Add enable_logit option to application annotations

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -5,11 +5,13 @@ locals {
   http_probe_enabled = var.is_web && var.probe_path != null
   exec_probe_enabled = !var.is_web && length(var.probe_command) != 0
   probe_enabled      = local.http_probe_enabled || local.exec_probe_enabled
-  prometheus_scrape_annotations = {
+
+  prometheus_scrape_annotations = var.enable_prometheus_monitoring ? {
     "prometheus.io/scrape" = "true"
     "prometheus.io/path"   = "/metrics"
     "prometheus.io/port"   = var.web_port
-  }
+  } : {}
+  logit_annotations = var.enable_logit ? { "logit.io/send" = "true" } : {}
 }
 
 resource "kubernetes_deployment" "main" {
@@ -33,7 +35,7 @@ resource "kubernetes_deployment" "main" {
           app = local.app_name
         }
 
-        annotations = var.enable_prometheus_monitoring ? local.prometheus_scrape_annotations : {}
+        annotations = merge(local.prometheus_scrape_annotations, local.logit_annotations)
 
       }
 

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br>    resource_group_name = string,<br>    resource_prefix     = string,<br>    dns_zone_prefix     = optional(string),<br>    cpu_min             = number<br>  })</pre> | n/a | yes |
 | <a name="input_command"></a> [command](#input\_command) | Custom command that overwrites Docker image | `list(string)` | `[]` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Path to the docker image | `string` | n/a | yes |
+| <a name="input_enable_logit"></a> [enable\_logit](#input\_enable\_logit) | A boolean to indicate whether to enable sending container logs to logit.io | `bool` | `false` | no |
 | <a name="input_enable_prometheus_monitoring"></a> [enable\_prometheus\_monitoring](#input\_enable\_prometheus\_monitoring) | a boolean to indicate whether to scrape(true) custom metrics for application or not(false) | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
 | <a name="input_github_personal_access_token"></a> [github\_personal\_access\_token](#input\_github\_personal\_access\_token) | Github Personal Access Token (PAT) of github\_username | `string` | `null` | no |

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -140,3 +140,9 @@ variable "azure_enable_monitoring" {
   default     = false
   description = "Whether to enable monitoring of container failures"
 }
+
+variable "enable_logit" {
+  type        = bool
+  default     = false
+  description = "A boolean to indicate whether to enable sending container logs to logit.io"
+}


### PR DESCRIPTION
## Context
Add enable_logit option for the aks application module.
Setting to true will enable pod log forwarding for that deployment.

https://trello.com/c/WTWtPR8H/906-spike-application-log-shipping 

## Changes proposed in this pull request
application module terraform updates.
New variable enable_logit with default false

## Guidance to review
Deploy an app using this branch and pass enable_logit with true value
Requires associated teacher-services-cloud PR to have been merged first.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
