### PR TITLE
[1730] Increase default alert thresholds to 80%

### DIFF
--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -48,18 +48,18 @@ No modules.
 | <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Password of the admin user | `string` | `null` | no |
 | <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | Username of the admin user | `string` | `null` | no |
 | <a name="input_alert_window_size"></a> [alert\_window\_size](#input\_alert\_window\_size) | The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H | `string` | `"PT5M"` | no |
-| <a name="input_azure_cpu_threshold"></a> [azure\_cpu\_threshold](#input\_azure\_cpu\_threshold) | n/a | `number` | `60` | no |
+| <a name="input_azure_cpu_threshold"></a> [azure\_cpu\_threshold](#input\_azure\_cpu\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_azure_enable_backup_storage"></a> [azure\_enable\_backup\_storage](#input\_azure\_enable\_backup\_storage) | n/a | `bool` | `true` | no |
 | <a name="input_azure_enable_high_availability"></a> [azure\_enable\_high\_availability](#input\_azure\_enable\_high\_availability) | n/a | `bool` | `false` | no |
 | <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | n/a | `bool` | `true` | no |
 | <a name="input_azure_extensions"></a> [azure\_extensions](#input\_azure\_extensions) | n/a | `list(string)` | `[]` | no |
 | <a name="input_azure_maintenance_window"></a> [azure\_maintenance\_window](#input\_azure\_maintenance\_window) | n/a | <pre>object({<br>    day_of_week  = optional(number)<br>    start_hour   = optional(number)<br>    start_minute = optional(number)<br>  })</pre> | `null` | no |
-| <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `75` | no |
+| <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_azure_name_override"></a> [azure\_name\_override](#input\_azure\_name\_override) | Replace the generated name with hardcoded name | `string` | `null` | no |
 | <a name="input_azure_resource_prefix"></a> [azure\_resource\_prefix](#input\_azure\_resource\_prefix) | Prefix of Azure resources for the service | `string` | n/a | yes |
 | <a name="input_azure_sku_name"></a> [azure\_sku\_name](#input\_azure\_sku\_name) | n/a | `string` | `"B_Standard_B1ms"` | no |
 | <a name="input_azure_storage_mb"></a> [azure\_storage\_mb](#input\_azure\_storage\_mb) | n/a | `number` | `32768` | no |
-| <a name="input_azure_storage_threshold"></a> [azure\_storage\_threshold](#input\_azure\_storage\_threshold) | n/a | `number` | `75` | no |
+| <a name="input_azure_storage_threshold"></a> [azure\_storage\_threshold](#input\_azure\_storage\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br>    resource_group_name = string,<br>    resource_prefix     = string,<br>    dns_zone_prefix     = optional(string),<br>    cpu_min             = number<br>  })</pre> | n/a | yes |
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -105,17 +105,17 @@ variable "azure_extensions" {
 
 variable "azure_memory_threshold" {
   type    = number
-  default = 75
+  default = 80
 }
 
 variable "azure_cpu_threshold" {
   type    = number
-  default = 60
+  default = 80
 }
 
 variable "azure_storage_threshold" {
   type    = number
-  default = 75
+  default = 80
 }
 
 variable "azure_enable_monitoring" {

--- a/aks/redis/tfdocs.md
+++ b/aks/redis/tfdocs.md
@@ -37,7 +37,7 @@ No modules.
 | <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | n/a | `bool` | `true` | no |
 | <a name="input_azure_family"></a> [azure\_family](#input\_azure\_family) | n/a | `string` | `"C"` | no |
 | <a name="input_azure_maxmemory_policy"></a> [azure\_maxmemory\_policy](#input\_azure\_maxmemory\_policy) | n/a | `string` | `"allkeys-lru"` | no |
-| <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `60` | no |
+| <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_azure_minimum_tls_version"></a> [azure\_minimum\_tls\_version](#input\_azure\_minimum\_tls\_version) | n/a | `string` | `"1.2"` | no |
 | <a name="input_azure_patch_schedule"></a> [azure\_patch\_schedule](#input\_azure\_patch\_schedule) | n/a | <pre>list(object({<br>    day_of_week        = string,<br>    start_hour_utc     = optional(number),<br>    maintenance_window = optional(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_azure_public_network_access_enabled"></a> [azure\_public\_network\_access\_enabled](#input\_azure\_public\_network\_access\_enabled) | n/a | `bool` | `false` | no |

--- a/aks/redis/variables.tf
+++ b/aks/redis/variables.tf
@@ -85,7 +85,7 @@ variable "azure_public_network_access_enabled" {
 
 variable "azure_memory_threshold" {
   type    = number
-  default = 60
+  default = 80
 }
 
 variable "azure_maxmemory_policy" {
@@ -116,4 +116,3 @@ variable "alert_window_size" {
   nullable    = false
   description = "The period of time that is used to monitor alert activity e.g PT1M, PT5M, PT15M, PT30M, PT1H, PT6H or PT12H"
 }
-


### PR DESCRIPTION
## Context
We're receiving alerts about postgres CPU usage but the team is not concerned when it's only briefly above 60%

## Changes proposed in this pull request
Change default thresholds to 80%

## Guidance to review
Run terraform-plan from a service environment with monitoring enabled

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
