### PR TITLE
[1707] Allow adding multiple DNS zones to a single front door

### DIFF
--- a/domains/environment_domains/README.md
+++ b/domains/environment_domains/README.md
@@ -1,0 +1,29 @@
+# Environment domains
+
+Create all domains for an environment. This includes the DNS records and the front door resources.
+
+By default a single frontdoor works for a single DNS zone. When adding more zones, use the add_to_front_door variable.
+
+## Usage
+
+```terraform
+module "domains" {
+  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains"
+  zone                = var.zone1
+  front_door_name     = var.front_door_name
+  resource_group_name = var.resource_group_name
+  domains             = var.domains1
+  environment         = var.environment_short
+  host_name           = var.origin_hostname1
+}
+
+module "additional_domains" {
+  source              = "git::https://github.com/DFE-Digital/terraform-modules.git//domains/environment_domains"
+  zone                = var.zone2
+  add_to_front_door   = var.front_door_name
+  resource_group_name = var.resource_group_name
+  domains             = var.domains2
+  environment         = var.environment_short
+  host_name           = var.origin_hostname2
+}
+```

--- a/domains/environment_domains/dns.tf
+++ b/domains/environment_domains/dns.tf
@@ -36,7 +36,7 @@ resource "azurerm_dns_cname_record" "main" {
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  record              = azurerm_cdn_frontdoor_endpoint.main[each.key].host_name
+  record              = var.add_to_endpoint_host_name == null ? azurerm_cdn_frontdoor_endpoint.main[each.key].host_name : var.add_to_endpoint_host_name
 }
 
 resource "azurerm_dns_a_record" "main" {
@@ -46,5 +46,5 @@ resource "azurerm_dns_a_record" "main" {
   zone_name           = data.azurerm_dns_zone.main.name
   resource_group_name = var.resource_group_name
   ttl                 = 300
-  target_resource_id  = azurerm_cdn_frontdoor_endpoint.main[each.key].id
+  target_resource_id  = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[each.key].id : var.add_to_endpoint_id
 }

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -4,7 +4,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
-  for_each = toset(var.domains)
+  for_each = var.add_to_front_door == null ? toset(var.domains) : {}
 
   name                     = substr("${replace(each.value, ".", "-")}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
@@ -47,7 +47,7 @@ resource "azurerm_cdn_frontdoor_route" "main" {
   depends_on                    = [azurerm_cdn_frontdoor_origin_group.main, azurerm_cdn_frontdoor_origin.main]
   for_each                      = toset(var.domains)
   name                          = var.add_to_front_door == null ? "${var.environment}-rt" : "${var.environment}-${local.name_suffix}-rt"
-  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.main[each.key].id
+  cdn_frontdoor_endpoint_id     = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[each.key].id : var.add_to_endpoint_id
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]
   cdn_frontdoor_rule_set_ids = concat(
@@ -65,7 +65,7 @@ resource "azurerm_cdn_frontdoor_route" "main" {
 resource "azurerm_cdn_frontdoor_route" "cached" {
   for_each                      = toset(local.cached_domain_list)
   name                          = var.add_to_front_door == null ? "${var.environment}-cached-rt" : "${var.environment}-${local.name_suffix}-cached-rt"
-  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.main[each.key].id
+  cdn_frontdoor_endpoint_id     = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[each.key].id : var.add_to_endpoint_id
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.main.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]
   cdn_frontdoor_rule_set_ids = concat(

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -4,7 +4,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
-  for_each = var.add_to_front_door == null ? toset(var.domains) : toset({})
+  for_each = var.add_to_front_door == null ? toset(var.domains) : toset([])
 
   name                     = substr("${replace(each.value, ".", "-")}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id

--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -4,7 +4,7 @@ data "azurerm_cdn_frontdoor_profile" "main" {
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "main" {
-  for_each = var.add_to_front_door == null ? toset(var.domains) : {}
+  for_each = var.add_to_front_door == null ? toset(var.domains) : toset({})
 
   name                     = substr("${replace(each.value, ".", "-")}-${local.endpoint_zone_name}", 0, local.max_frontdoor_endpoint_name_length)
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id

--- a/domains/environment_domains/front_door_rules.tf
+++ b/domains/environment_domains/front_door_rules.tf
@@ -1,7 +1,7 @@
 resource "azurerm_cdn_frontdoor_rule_set" "redirects" {
   count = length(var.redirect_rules) > 0 ? 1 : 0
 
-  name                     = "${var.environment}Redirects"
+  name                     = var.add_to_front_door == null ? "${var.environment}Redirects" : "${var.environment}${local.name_suffix}Redirects"
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
 }
 

--- a/domains/environment_domains/locals.tf
+++ b/domains/environment_domains/locals.tf
@@ -9,4 +9,6 @@ locals {
   cached_domain_list = length(var.cached_paths) > 0 ? var.domains : []
 
   max_frontdoor_endpoint_name_length = 46
+
+  name_suffix = replace(var.zone, ".", "-")
 }

--- a/domains/environment_domains/output.tf
+++ b/domains/environment_domains/output.tf
@@ -1,0 +1,6 @@
+output "endpoint_host_name" {
+  value = var.add_to_endpoint_host_name == null ? azurerm_cdn_frontdoor_endpoint.main[0].host_name : var.add_to_endpoint_host_name
+}
+output "endpoint_id" {
+  value = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[0].id : var.add_to_endpoint_id
+}

--- a/domains/environment_domains/output.tf
+++ b/domains/environment_domains/output.tf
@@ -1,6 +1,6 @@
 output "endpoint_host_name" {
-  value = var.add_to_endpoint_host_name == null ? azurerm_cdn_frontdoor_endpoint.main[0].host_name : var.add_to_endpoint_host_name
+  value = var.add_to_endpoint_host_name == null ? azurerm_cdn_frontdoor_endpoint.main[var.domains[0]].host_name : var.add_to_endpoint_host_name
 }
 output "endpoint_id" {
-  value = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[0].id : var.add_to_endpoint_id
+  value = var.add_to_endpoint_id == null ? azurerm_cdn_frontdoor_endpoint.main[var.domains[0]].id : var.add_to_endpoint_id
 }

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -36,13 +36,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_add_to_front_door"></a> [add\_to\_front\_door](#input\_add\_to\_front\_door) | Add domains of a different zone to existing front door domains | `string` | `null` | no |
 | <a name="input_cached_paths"></a> [cached\_paths](#input\_cached\_paths) | List of path patterns such as /packs/* that front door will cache | `list(string)` | `[]` | no |
 | <a name="input_domains"></a> [domains](#input\_domains) | List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use | `any` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `any` | n/a | yes |
 | <a name="input_exclude_cnames"></a> [exclude\_cnames](#input\_exclude\_cnames) | Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration. | `list` | `[]` | no |
-| <a name="input_front_door_name"></a> [front\_door\_name](#input\_front\_door\_name) | n/a | `any` | n/a | yes |
+| <a name="input_front_door_name"></a> [front\_door\_name](#input\_front\_door\_name) | Name of the front door where the domains will be created. Use var.add\_to\_front\_door if adding to existing domains. | `any` | `null` | no |
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | Origin host name ie domain to where front door sends the requests. It may not be used if all requests are redirected. | `string` | `"not-in-use.education.gov.uk"` | no |
-| <a name="input_multiple_hosted_zones"></a> [multiple\_hosted\_zones](#input\_multiple\_hosted\_zones) | n/a | `bool` | `false` | no |
+| <a name="input_multiple_hosted_zones"></a> [multiple\_hosted\_zones](#input\_multiple\_hosted\_zones) | Avoid endpoint naming clash when using multiple zones (one for each front door) | `bool` | `false` | no |
 | <a name="input_null_host_header"></a> [null\_host\_header](#input\_null\_host\_header) | The origin\_host\_header for the azurerm\_cdn\_frontdoor\_origin resource will be var.host\_name (if false) or null (if true). If null then the host name from the incoming request will be used. | `bool` | `false` | no |
 | <a name="input_redirect_rules"></a> [redirect\_rules](#input\_redirect\_rules) | List of ordered redirect rules with format:<br>    [<br>      {<br>        "from-domain": "One of the domains from var.domains to redirect from",<br>        "to-domain": "Redirect destination domain",<br>        "to-path": "Optional path appended to the destination URL. If not provided, the path will be the same as in the incoming request",<br>        "to-query-string": "Optional path appended to the destination URL. If not provided, defaults to empty string"<br>      },<br>      {<br>        ...<br>      }<br>    ] | `map` | `{}` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `any` | n/a | yes |

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -71,3 +71,10 @@ variable "redirect_rules" {
     ]
   EOF
 }
+
+variable "add_to_endpoint_host_name" {
+  default = null
+}
+variable "add_to_endpoint_id" {
+  default = null
+}

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -1,5 +1,9 @@
 variable "zone" {}
-variable "front_door_name" {}
+variable "front_door_name" {
+  description = "Name of the front door where the domains will be created. Use var.add_to_front_door if adding to existing domains."
+  default     = null
+}
+
 variable "resource_group_name" {}
 variable "domains" {
   description = <<EOF
@@ -25,9 +29,16 @@ variable "rule_set_ids" {
 }
 
 variable "multiple_hosted_zones" {
-  type     = bool
-  nullable = false
-  default  = false
+  type        = bool
+  nullable    = false
+  default     = false
+  description = "Avoid endpoint naming clash when using multiple zones (one for each front door)"
+}
+
+variable "add_to_front_door" {
+  type        = string
+  default     = null
+  description = "Add domains of a different zone to existing front door domains"
 }
 
 variable "cached_paths" {


### PR DESCRIPTION
## Context
Each front door has a monthly cost so we can save by serving more domains instead of creating a new front door for each zone

## Changes proposed in this pull request
Add variable `add_to_front_door` to namespace all resources inside of front door and avoid clashes.

## Guidance to review
Test with TRS

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
