### PR TITLE
Add log analytics containerlog exclude for logit

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -11,7 +11,11 @@ locals {
     "prometheus.io/path"   = "/metrics"
     "prometheus.io/port"   = var.web_port
   } : {}
-  logit_annotations = var.enable_logit ? { "logit.io/send" = "true" } : {}
+
+  logit_annotations = var.enable_logit ? {
+    "logit.io/send"        = "true"
+    "fluentbit.io/exclude" = "true"
+  } : {}
 
   maintenance_service_port = 80
 }


### PR DESCRIPTION
## Context

If enable_logit is set for an app env, we will send container logs to both logit and azure log analytics
This adds an annotation that will disable the send to azure log analytics when logit is enabled
This will save costs as we won't be storing logs in 2 places

https://trello.com/c/EBBpNMZG/1780-review-log-analytics-cost-savings

## Changes proposed in this pull request
Update logit_annotations to include "fluentbit.io/exclude" = "true"

This will only work if log_collection_settings.filter_using_annotations is enabled for k8s ama-logs

## Guidance to review
Can point a service to this branch, enable_logit and run deploy-plan
and/or check dev cluster6 where this has been enabled for apply_review_rm9

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
