### PR TITLE
[1806] Prevent statuscake SSL checks from following redirects

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -24,9 +24,8 @@ resource "statuscake_uptime_check" "main" {
 resource "statuscake_ssl_check" "main" {
   for_each = toset(var.ssl_urls)
 
-  contact_groups   = var.contact_groups
-  check_interval   = 3600
-  follow_redirects = true
+  contact_groups = var.contact_groups
+  check_interval = 3600
 
   alert_config {
     alert_at = [3, 7, 30] # 1 month, 1 week then 3 days before expiration


### PR DESCRIPTION
## Context
When a domain is set up with a redirect, the StatusCake SSL check was following the redirect and got the data of the end website certificate. For instance, https://professional-development-for-teachers-leaders.education.gov.uk/ redirects to https://www.gov.uk/guidance/national-professional-qualification-npq-courses. So the check was on www.gov.uk instead of professional-evelopment-for-teachers-leaders.education.gov.uk.

## Changes proposed in this pull request
Remove the follow redirect option

## Guidance to review
Tested from cpd-information:

```
Terraform will perform the following actions:

  # module.statuscake.statuscake_ssl_check.main["https://professional-development-for-teachers-leaders.education.gov.uk/"] will be updated in-place
  ~ resource "statuscake_ssl_check" "main" {
      ~ follow_redirects = true -> false
        id               = "320866"
        # (3 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
