### PR TITLE
[1815] Fix alert threshold message

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -179,7 +179,7 @@ resource "azurerm_monitor_metric_alert" "cpu" {
   name                = "${azurerm_postgresql_flexible_server.main[0].name}-cpu"
   resource_group_name = data.azurerm_resource_group.main[0].name
   scopes              = [azurerm_postgresql_flexible_server.main[0].id]
-  description         = "Action will be triggered when cpu use is greater than 60%"
+  description         = "Action will be triggered when cpu use is greater than ${var.azure_cpu_threshold}%"
   window_size         = var.alert_window_size
 
   criteria {
@@ -207,7 +207,7 @@ resource "azurerm_monitor_metric_alert" "storage" {
   name                = "${azurerm_postgresql_flexible_server.main[0].name}-storage"
   resource_group_name = data.azurerm_resource_group.main[0].name
   scopes              = [azurerm_postgresql_flexible_server.main[0].id]
-  description         = "Action will be triggered when storage use is greater than 75%"
+  description         = "Action will be triggered when storage use is greater than ${var.azure_storage_threshold}%"
   window_size         = var.alert_window_size
 
   criteria {

--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -84,7 +84,7 @@ resource "azurerm_monitor_metric_alert" "memory" {
   name                = "${azurerm_redis_cache.main[0].name}-memory"
   resource_group_name = data.azurerm_resource_group.main[0].name
   scopes              = [azurerm_redis_cache.main[0].id]
-  description         = "Action will be triggered when memory use is greater than 60%"
+  description         = "Action will be triggered when memory use is greater than ${var.azure_memory_threshold}%"
   window_size         = var.alert_window_size
 
   criteria {


### PR DESCRIPTION
## Context
The message had a hardcoded value but the actual threshold was changed

## Changes proposed in this pull request
Make the threshold in the description use the variable

## Guidance to review
Run deploy-plan from Apply:
```
  # module.postgres.azurerm_monitor_metric_alert.cpu[0] will be updated in-place
  ~ resource "azurerm_monitor_metric_alert" "cpu" {
      ~ description         = "Action will be triggered when cpu use is greater than 60%" -> "Action will be triggered when cpu use is greater than 80%"
        id                  = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.Insights/metricAlerts/s189p01-att-production-psql-cpu"
        name                = "s189p01-att-production-psql-cpu"
        tags                = {
            "Environment"      = "Prod"
            "Product"          = "Apply for postgraduate teacher training"
            "Service Offering" = "Apply for postgraduate teacher training"
        }
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.postgres.azurerm_monitor_metric_alert.storage[0] will be updated in-place
  ~ resource "azurerm_monitor_metric_alert" "storage" {
      ~ description         = "Action will be triggered when storage use is greater than 75%" -> "Action will be triggered when storage use is greater than 80%"
        id                  = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.Insights/metricAlerts/s189p01-att-production-psql-storage"
        name                = "s189p01-att-production-psql-storage"
        tags                = {
            "Environment"      = "Prod"
            "Product"          = "Apply for postgraduate teacher training"
            "Service Offering" = "Apply for postgraduate teacher training"
        }
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.redis-cache.azurerm_monitor_metric_alert.memory[0] will be updated in-place
  ~ resource "azurerm_monitor_metric_alert" "memory" {
      ~ description         = "Action will be triggered when memory use is greater than 60%" -> "Action will be triggered when memory use is greater than 80%"
        id                  = "/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-att-pd-rg/providers/Microsoft.Insights/metricAlerts/s189p01-att-production-redis-cache-memory"
        name                = "s189p01-att-production-redis-cache-memory"
        tags                = {
            "Environment"      = "Prod"
            "Product"          = "Apply for postgraduate teacher training"
            "Service Offering" = "Apply for postgraduate teacher training"
        }
        # (7 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
