### PR TITLE
[1762] Enable GCP workload identity federation

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -17,6 +17,10 @@ locals {
     "fluentbit.io/exclude" = "true"
   } : {}
 
+  gcp_wif_label = var.enable_gcp_wif ? {
+    "azure.workload.identity/use" = "true"
+  } : {}
+
   maintenance_service_port = 80
 }
 
@@ -37,15 +41,13 @@ resource "kubernetes_deployment" "main" {
 
     template {
       metadata {
-        labels = {
-          app = local.app_name
-        }
-
+        labels      = merge({ app = local.app_name }, local.gcp_wif_label)
         annotations = merge(local.prometheus_scrape_annotations, local.logit_annotations)
-
       }
 
       spec {
+        service_account_name = var.enable_gcp_wif ? "gcp-wif" : null
+
         node_selector = {
           "teacherservices.cloud/node_pool" = "applications"
           "kubernetes.io/os"                = "linux"

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -35,6 +35,7 @@ No modules.
 | <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br>    resource_group_name = string,<br>    resource_prefix     = string,<br>    dns_zone_prefix     = optional(string),<br>    cpu_min             = number<br>  })</pre> | n/a | yes |
 | <a name="input_command"></a> [command](#input\_command) | Custom command that overwrites Docker image | `list(string)` | `[]` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Path to the docker image | `string` | n/a | yes |
+| <a name="input_enable_gcp_wif"></a> [enable\_gcp\_wif](#input\_enable\_gcp\_wif) | Let the deployment use the GCP workload identity federation service account to get a token | `string` | `false` | no |
 | <a name="input_enable_logit"></a> [enable\_logit](#input\_enable\_logit) | A boolean to indicate whether to enable sending container logs to logit.io | `bool` | `false` | no |
 | <a name="input_enable_prometheus_monitoring"></a> [enable\_prometheus\_monitoring](#input\_enable\_prometheus\_monitoring) | a boolean to indicate whether to scrape(true) custom metrics for application or not(false) | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -153,3 +153,9 @@ variable "send_traffic_to_maintenance_page" {
   default     = false
   nullable    = false
 }
+
+variable "enable_gcp_wif" {
+  type        = string
+  default     = false
+  description = "Let the deployment use the GCP workload identity federation service account to get a token"
+}


### PR DESCRIPTION
## Context
The namespaces are being configured with WIF. This allows apps to use it.

## Changes proposed in this pull request
Add variable enable_gcp_wif to bind to the service account

## Guidance to review
Tested and demoed with https://github.com/DFE-Digital/register-trainee-teachers/pull/4325

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
