### PR TITLE
Change deployment liveness probe settings

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -134,9 +134,9 @@ resource "kubernetes_deployment" "main" {
                 }
               }
 
-              failure_threshold = 10
-              period_seconds    = 1
-              timeout_seconds   = 10
+              failure_threshold = 5
+              period_seconds    = 5
+              timeout_seconds   = 5
             }
           }
 


### PR DESCRIPTION
## Context
https://trello.com/c/p9TYi8Rp/1850-decrease-container-liveness-probes

Application deployment Liveness probe settings need tuning
Current setting generates a lot of probe activity and log entries per container. 

## Changes proposed in this pull request
Old settings 
- failure_threshold = 10, period_seconds = 1, timeout_seconds = 10
- i.e. 1 probe per second, 10 consecutive failures (9s after first failure) trigger container replacement, 10s timeout

New settings
- failure_threshold = 5, period_seconds = 5, timeout_seconds = 5
- i.e. 1 probe per 5 seconds, 5 consecutive failures (20s after first failure) trigger container replacement, 5s timeout

## Guidance to review
deploy-plan from a service pointed to this branch

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
