### PR TITLE
Add soft delete for storage backup

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -116,6 +116,16 @@ resource "azurerm_storage_account" "backup" {
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
 
+  blob_properties {
+    delete_retention_policy {
+      days = 7
+    }
+
+    container_delete_retention_policy {
+      days = 7
+    }
+  }
+
   lifecycle { ignore_changes = [tags] }
 }
 


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
To prevent accidental or malicious deletion, we need to add soft delete to storage accoun

## Changes proposed in this pull request
Add soft delete to [terraform-modules/aks/postgres/resources.tf at main · DFE-Digital/terraform-modules](https://github.com/DFE-Digital/terraform-modules/blob/main/aks/postgres/resources.tf#L108)
i.e. add a delete_retention_policy of 7 days for blobs and containers


## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
