### PR TITLE
Connection throttling added to postgresql

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -96,6 +96,14 @@ resource "azurerm_postgresql_flexible_server_configuration" "max_connections" {
   value     = 856 # Maximum on GP_Standard_D2ds_v4. See: https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-limits#maximum-connections
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "connection_throttling" {
+  count = var.use_azure ? 1 : 0
+  # Parameter connection_throttling = on enables temporary connection throttling per IP for too many login failures
+  name      = "connection_throttle.enable"
+  server_id = azurerm_postgresql_flexible_server.main[0].id
+  value     = "on"
+}
+
 resource "azurerm_postgresql_flexible_server_database" "main" {
   count = var.use_azure ? 1 : 0
 

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -25,6 +25,7 @@ No modules.
 | [azurerm_monitor_metric_alert.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_postgresql_flexible_server.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
 | [azurerm_postgresql_flexible_server_configuration.azure_extensions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
+| [azurerm_postgresql_flexible_server_configuration.connection_throttling](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_connections](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_storage_account.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |


### PR DESCRIPTION
## Context
Connection throttling added to postgresql config.
## Changes proposed in this pull request
Added config connection_throttling = on

## Guidance to review
Added config connection_throttling = on

QA Terraform plan  for get-a-teacher-relocation-payment: https://github.com/DFE-Digital/get-a-teacher-relocation-payment/pull/427/files

# module.postgres.azurerm_postgresql_flexible_server_configuration.connection_throttling[0] will be created
  + resource "azurerm_postgresql_flexible_server_configuration" "connection_throttling" {
      + id        = (known after apply)
      + name      = "connection_throttling"
      + server_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-trp-qa-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/s189t01-trp-qa-pg"
      + value     = "on"
    }
 
## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
