### PR TITLE
[1891] Enable RuntimeDefault seccomp profile on containers

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -165,6 +165,12 @@ resource "kubernetes_deployment" "main" {
               period_seconds    = 5
             }
           }
+
+          security_context {
+            seccomp_profile {
+              type = "RuntimeDefault"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Set the RuntimeDefault seccomp profile as customisation may not be needed at this time.

<!-- Delete sections if not required -->

## Context
ITHC recommendations to improve container security

Seccomp stands for secure computing mode. It can be used to sandbox the privileges of a process, restricting the calls it is able to make from userspace into the kernel.

## Changes proposed in this pull request
Set seccompt default profile in the application module

## Guidance to review
Check Register review app: https://register-pr-4416.test.teacherservices.cloud/ ([PR](https://github.com/DFE-Digital/register-trainee-teachers/pull/4416))

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
