### PR TITLE
[1839] Fix ConflictingPublicNetworkAccessAndVirtualNetworkConfiguration

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -85,7 +85,8 @@ resource "azurerm_postgresql_flexible_server" "main" {
       # Allow Azure to manage primary and standby server on fail-over. Ignore changes.
       high_availability[0].standby_availability_zone,
       # Required for import because of https://github.com/hashicorp/terraform-provider-azurerm/issues/15586
-      create_mode
+      create_mode,
+      public_network_access_enabled
     ]
   }
 }


### PR DESCRIPTION
## Context
Related to issue https://github.com/hashicorp/terraform-provider-azurerm/issues/26098

We must ignore changes to the public_network_access_enabled argument as it becomes enforced from azurerm version v3.105.0.
This will allow us to upgrade azurerm in all the repositories. Then we will be able to set public_network_access_enabled to false and remove this ignore_changes.

## Changes proposed in this pull request
Add public_network_access_enabled to ignore_changes lifecycle

## Guidance to review
See testing in https://hedgedoc.teacherservices.cloud/GfdrzaeGRKGO49k69ANvrQ?edit

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
