### PR TITLE
[1839] Disable public_network_access_enabled on postgres

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -49,17 +49,18 @@ locals {
 resource "azurerm_postgresql_flexible_server" "main" {
   count = var.use_azure ? 1 : 0
 
-  name                   = local.azure_name
-  location               = data.azurerm_resource_group.main[0].location
-  resource_group_name    = data.azurerm_resource_group.main[0].name
-  version                = var.server_version
-  administrator_login    = local.database_username
-  administrator_password = local.database_password
-  create_mode            = "Default"
-  storage_mb             = var.azure_storage_mb
-  sku_name               = var.azure_sku_name
-  delegated_subnet_id    = data.azurerm_subnet.main[0].id
-  private_dns_zone_id    = data.azurerm_private_dns_zone.main[0].id
+  name                          = local.azure_name
+  location                      = data.azurerm_resource_group.main[0].location
+  resource_group_name           = data.azurerm_resource_group.main[0].name
+  version                       = var.server_version
+  administrator_login           = local.database_username
+  administrator_password        = local.database_password
+  create_mode                   = "Default"
+  storage_mb                    = var.azure_storage_mb
+  sku_name                      = var.azure_sku_name
+  delegated_subnet_id           = data.azurerm_subnet.main[0].id
+  private_dns_zone_id           = data.azurerm_private_dns_zone.main[0].id
+  public_network_access_enabled = false
 
   dynamic "high_availability" {
     for_each = var.azure_enable_high_availability ? [1] : []
@@ -85,8 +86,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
       # Allow Azure to manage primary and standby server on fail-over. Ignore changes.
       high_availability[0].standby_availability_zone,
       # Required for import because of https://github.com/hashicorp/terraform-provider-azurerm/issues/15586
-      create_mode,
-      public_network_access_enabled
+      create_mode
     ]
   }
 }


### PR DESCRIPTION
## Context
Related to issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/26098

The property must be set explicitly or it defaults to true. All providers have been updated to be able to use it.

## Changes proposed in this pull request
- remove lifecycle to ignore change to public_network_access_enabled
- Explicitly set public_network_access_enabled to false

## Guidance to review
Test branch 1839-temp on ECF
`make production terraform-plan CONFIRM_PRODUCTION=y DOCKER_IMAGE=ghcr.io/dfe-digital/early-careers-framework:a9ed25957fb1190234e8289c71576611a401833e `
should show no change to postgres

## Before merging
Make sure all providers have been updated

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
