### PR TITLE
[1995] Set deployment stragegy to recreate for non web deployments

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -39,6 +39,10 @@ resource "kubernetes_deployment" "main" {
       }
     }
 
+    strategy {
+      type = var.is_web ? "RollingUpdate" : "Recreate"
+    }
+
     template {
       metadata {
         labels      = merge({ app = local.app_name }, local.gcp_wif_label)


### PR DESCRIPTION
## Context
Background workers may have issues if 2 versions run at the same time. Since they don't receive user traffic, it does not matter if they are stopped while getting replaced.

## Changes proposed in this pull request
Use the Recreate deployment strategy when the deployment is not a web app

## Guidance to review
Deploy https://github.com/DFE-Digital/apply-for-teacher-training/pull/9742 alternatively:
- `make review_aks deploy PR_NUMBER=9742 IMAGE_TAG=daf97fd0483cf5e9e2d885621a209b8f3da703e5`
- `make review_aks deploy PR_NUMBER=9742 IMAGE_TAG=main`

Observe pods:
- `watch -n 1 "kubectl -n bat-qa get pods | grep 9742"`

The web app creates a new one before terminating the initial one. The workers simply terminate and create.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
