### PR TITLE
Add statuscake heartbeat check

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -21,6 +21,18 @@ resource "statuscake_uptime_check" "main" {
   }
 }
 
+resource "statuscake_heartbeat_check" "main" {
+  for_each = toset(var.heartbeat_names)
+
+  name           = each.value
+  period         = var.heartbeat_period
+  contact_groups = var.contact_groups
+}
+
+output "heartbeat_check_urls" {
+  value = { for name in var.heartbeat_names : name => statuscake_heartbeat_check.main[name].check_url }
+}
+
 resource "statuscake_ssl_check" "main" {
   for_each = toset(var.ssl_urls)
 

--- a/monitoring/statuscake/tfdocs.md
+++ b/monitoring/statuscake/tfdocs.md
@@ -16,6 +16,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [statuscake_heartbeat_check.main](https://registry.terraform.io/providers/StatusCakeDev/statuscake/latest/docs/resources/heartbeat_check) | resource |
 | [statuscake_ssl_check.main](https://registry.terraform.io/providers/StatusCakeDev/statuscake/latest/docs/resources/ssl_check) | resource |
 | [statuscake_uptime_check.main](https://registry.terraform.io/providers/StatusCakeDev/statuscake/latest/docs/resources/uptime_check) | resource |
 
@@ -25,9 +26,13 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_confirmation"></a> [confirmation](#input\_confirmation) | Retry the check when an error is detected to avoid false positives and micro downtimes | `number` | `2` | no |
 | <a name="input_contact_groups"></a> [contact\_groups](#input\_contact\_groups) | Contact groups for the alerts | `list(string)` | `[]` | no |
+| <a name="input_heartbeat_names"></a> [heartbeat\_names](#input\_heartbeat\_names) | List of names for the heartbeat checks | `list(string)` | `[]` | no |
+| <a name="input_heartbeat_period"></a> [heartbeat\_period](#input\_heartbeat\_period) | The period in seconds within which a heartbeat must be received | `number` | `600` | no |
 | <a name="input_ssl_urls"></a> [ssl\_urls](#input\_ssl\_urls) | Set of URLs to perform SSL checks on | `list(string)` | `[]` | no |
 | <a name="input_uptime_urls"></a> [uptime\_urls](#input\_uptime\_urls) | Set of URLs to perform uptime checks on | `list(string)` | `[]` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_heartbeat_check_urls"></a> [heartbeat\_check\_urls](#output\_heartbeat\_check\_urls) | n/a |

--- a/monitoring/statuscake/variables.tf
+++ b/monitoring/statuscake/variables.tf
@@ -25,3 +25,17 @@ variable "confirmation" {
   description = "Retry the check when an error is detected to avoid false positives and micro downtimes"
   default     = 2
 }
+
+# Heartbeat check variables
+variable "heartbeat_names" {
+  type        = list(string)
+  nullable    = false
+  description = "List of names for the heartbeat checks"
+  default     = []
+}
+
+variable "heartbeat_period" {
+  description = "The period in seconds within which a heartbeat must be received"
+  type        = number
+  default     = 600
+}


### PR DESCRIPTION
## Context
Claims worker use [delayed jobs](https://github.com/collectiveidea/delayed_job). There is a known issue with it: when there is a database error, it stops processing jobs.
We should monitor it so we know when it's failed.

https://trello.com/c/PQgfB2yQ/1961-claims-worker-heartbeat-monitor

## Changes proposed in this pull request
Add a new module for statuscake heartbeat check


## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
