### PR TITLE
[860] Fix postgres database password issues with $$

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -41,7 +41,11 @@ resource "random_password" "password" {
 
 locals {
   database_username = var.admin_username != null ? var.admin_username : "u${random_string.username[0].result}"
-  database_password = var.admin_password != null ? var.admin_password : random_password.password[0].result
+
+  # Remove sequences of multiple dollar signs. Fix setting up the database password
+  # on the container as we use a shell environment variable for that
+  sanitised_password_string = replace(random_password.password[0].result, "/\\$+/", "$")
+  database_password         = var.admin_password != null ? var.admin_password : local.sanitised_password_string
 }
 
 # Azure


### PR DESCRIPTION
## Context
We set the postgres password in the container using a shell environment variable. If the variable contains a sequence of 2 dollar signs `$$`, the actual password may actually have only one `$`. Since the webapp is still configured with `$$`, they don't match and authentication fails.

## Changes proposed in this pull request
This commit replaces all sequences of multiple dollar signs with a single one.

## Guidance to review
Use terraform console:
```
% terraform console
> replace("ab$$cYJH$V&*$$$$£^d","/\\$+/","$")
"ab$cYJH$V&*$£^d"
```
See review app https://github.com/DFE-Digital/itt-mentor-services/pull/985: https://manage-school-placements-985.test.teacherservices.cloud/

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
