### PR TITLE
[860] Fix postgres when using existing database password

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -42,10 +42,10 @@ resource "random_password" "password" {
 locals {
   database_username = var.admin_username != null ? var.admin_username : "u${random_string.username[0].result}"
 
+  original_database_password = var.admin_password != null ? var.admin_password : random_password.password[0].result
   # Remove sequences of multiple dollar signs. Fix setting up the database password
   # on the container as we use a shell environment variable for that
-  sanitised_password_string = replace(random_password.password[0].result, "/\\$+/", "$")
-  database_password         = var.admin_password != null ? var.admin_password : local.sanitised_password_string
+  database_password = replace(local.original_database_password, "/\\$+/", "$")
 }
 
 # Azure


### PR DESCRIPTION
## Context
Pipeline failing in Apply for TT: https://github.com/DFE-Digital/apply-for-teacher-training/actions/runs/10684507769/job/29618041006

## Changes proposed in this pull request
Sanitise password in both cases: existing password and generated password

## Guidance to review
Run `make review_aks deploy-plan PR_NUMBER=9791` in Apply for TT

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
