### PR TITLE
Add delay to statuscake alert

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -4,7 +4,7 @@ resource "statuscake_uptime_check" "main" {
   name           = each.value
   contact_groups = var.contact_groups
   confirmation   = var.confirmation
-  trigger_rate   = 0
+  trigger_rate   = var.trigger_rate
   check_interval = 30
   regions        = ["london", "dublin"]
 

--- a/monitoring/statuscake/tfdocs.md
+++ b/monitoring/statuscake/tfdocs.md
@@ -29,6 +29,7 @@ No modules.
 | <a name="input_heartbeat_names"></a> [heartbeat\_names](#input\_heartbeat\_names) | List of names for the heartbeat checks | `list(string)` | `[]` | no |
 | <a name="input_heartbeat_period"></a> [heartbeat\_period](#input\_heartbeat\_period) | The period in seconds within which a heartbeat must be received | `number` | `600` | no |
 | <a name="input_ssl_urls"></a> [ssl\_urls](#input\_ssl\_urls) | Set of URLs to perform SSL checks on | `list(string)` | `[]` | no |
+| <a name="input_trigger_rate"></a> [trigger\_rate](#input\_trigger\_rate) | The number of minutes to wait before sending an alert | `number` | `0` | no |
 | <a name="input_uptime_urls"></a> [uptime\_urls](#input\_uptime\_urls) | Set of URLs to perform uptime checks on | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/monitoring/statuscake/variables.tf
+++ b/monitoring/statuscake/variables.tf
@@ -39,3 +39,10 @@ variable "heartbeat_period" {
   type        = number
   default     = 600
 }
+
+variable "trigger_rate" {
+  type        = number
+  description = "The number of minutes to wait before sending an alert"
+  default     = 0
+
+}


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
We receive alerts for brief downtimes such as https://ukgovernmentdfe.slack.com/archives/C011EM7HU85/p1726012917476049Connect your Slack account

In this case the healthcheck monitors the presence of sidekiq. But sidekiq may be briefly absent when it is redeployed. We should only alert if it remains down for a while.

## Changes proposed in this pull request
Add trigger_rate variable so that the value can be set when module is used

https://trello.com/c/8byYzOY9/2040-delay-statuscake-alerts

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
