### PR TITLE
[1974] Repeat London as StatusCake region

### DIFF
--- a/monitoring/statuscake/resources.tf
+++ b/monitoring/statuscake/resources.tf
@@ -6,7 +6,7 @@ resource "statuscake_uptime_check" "main" {
   confirmation   = var.confirmation
   trigger_rate   = var.trigger_rate
   check_interval = 30
-  regions        = ["london", "dublin"]
+  regions        = ["london", "london", "london"]
 
   http_check {
     follow_redirects = true


### PR DESCRIPTION
## Context
Each region has multiple StatusCake servers. If it is repeated, the confirmations will use another server in the same region. We want the London region as most of our users are in UK. Focusing on it means we may not alert if a service is down for London but available for another country, as may happen with the front door CDN

## Changes proposed in this pull request
Repeat 3 London regions

## Guidance to review
Check statuscake upptime check created from https://github.com/DFE-Digital/itt-mentor-services/pull/1029

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
