### PR TITLE
[2004] Remove NET_BIND_SERVICE container capability

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,10 +7,10 @@ jobs:
     name: Terraform Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.4.5"
+          terraform_version: "1.9.5"
       - name: Check formatting
         run: terraform fmt -recursive -check
 
@@ -18,8 +18,8 @@ jobs:
     name: Terraform Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: terraform-docs/gh-actions@main
+      - uses: actions/checkout@v4
+      - uses: terraform-docs/gh-actions@v1.2.2
         with:
           find-dir: .
           fail-on-diff: true
@@ -34,6 +34,6 @@ jobs:
     name: YAML
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check formatting
         uses: karancode/yamllint-github-action@v2.1.1

--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -179,7 +179,6 @@ resource "kubernetes_deployment" "main" {
 
             capabilities {
               drop = ["ALL"]
-              add  = ["NET_BIND_SERVICE"]
             }
           }
         }


### PR DESCRIPTION
## Context
Increase security by preventing processes inside the container from opening connections on privileged ports (0-1024).
All applications running on AKS run on unprivileged ports.

## Changes proposed in this pull request
- Drop all container capabilities, including NET_BIND_SERVICE
- Pin terraform-docs version to 1.2.2 because of issue: https://github.com/terraform-docs/gh-actions/issues/145

## Guidance to review
Review app on ITTMS: https://github.com/DFE-Digital/itt-mentor-services/pull/1052

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
