### PR TITLE
Adding redirect rules for security domains

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -52,7 +52,8 @@ resource "azurerm_cdn_frontdoor_route" "main" {
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]
   cdn_frontdoor_rule_set_ids = concat(
     var.rule_set_ids,
-    azurerm_cdn_frontdoor_rule_set.redirects[*].id
+    azurerm_cdn_frontdoor_rule_set.redirects[*].id,
+    [azurerm_cdn_frontdoor_rule_set.security_redirects.id]
   )
   link_to_default_domain          = false
   cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.main[each.key].id]
@@ -70,7 +71,8 @@ resource "azurerm_cdn_frontdoor_route" "cached" {
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.main.id]
   cdn_frontdoor_rule_set_ids = concat(
     var.rule_set_ids,
-    azurerm_cdn_frontdoor_rule_set.redirects[*].id
+    azurerm_cdn_frontdoor_rule_set.redirects[*].id,
+    [azurerm_cdn_frontdoor_rule_set.security_redirects.id]
   )
   link_to_default_domain          = false
   cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.main[each.key].id]

--- a/domains/environment_domains/front_door_security_rules.tf
+++ b/domains/environment_domains/front_door_security_rules.tf
@@ -1,0 +1,59 @@
+# Security and vulnerability disclosure redirects
+resource "azurerm_cdn_frontdoor_rule_set" "security_redirects" {
+  name                     = "${var.environment}SecurityRedirects"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
+}
+
+# Redirect for security.txt files
+resource "azurerm_cdn_frontdoor_rule" "security_txt" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.main, azurerm_cdn_frontdoor_origin.main]
+
+  name                      = "securityTxtRedirect"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.security_redirects.id
+  order                     = 0
+  behavior_on_match         = "Continue"
+
+  conditions {
+    url_path_condition {
+      operator     = "BeginsWith"
+      match_values = ["/.well-known/security.txt", "/security.txt"]
+      transforms   = ["Lowercase"]
+    }
+  }
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "PermanentRedirect"
+      redirect_protocol    = "Https"
+      destination_hostname = "vdp.security.education.gov.uk"
+      destination_path     = "/security.txt"
+    }
+  }
+}
+
+# Redirect for thanks.txt files
+resource "azurerm_cdn_frontdoor_rule" "thanks_txt" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.main, azurerm_cdn_frontdoor_origin.main]
+
+  name                      = "thanksTxtRedirect"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.security_redirects.id
+  order                     = 1
+  behavior_on_match         = "Continue"
+
+  conditions {
+    url_path_condition {
+      operator     = "BeginsWith"
+      match_values = ["/.well-known/thanks.txt", "/thanks.txt"]
+      transforms   = ["Lowercase"]
+    }
+  }
+
+  actions {
+    url_redirect_action {
+      redirect_type        = "PermanentRedirect"
+      redirect_protocol    = "Https"
+      destination_hostname = "vdp.security.education.gov.uk"
+      destination_path     = "/thanks.txt"
+    }
+  }
+}

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -24,7 +24,10 @@ No modules.
 | [azurerm_cdn_frontdoor_route.cached](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
 | [azurerm_cdn_frontdoor_route.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
 | [azurerm_cdn_frontdoor_rule.rule](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.security_txt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
+| [azurerm_cdn_frontdoor_rule.thanks_txt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_cdn_frontdoor_rule_set.security_redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_dns_a_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_cname_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
 | [azurerm_dns_txt_record.apex](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |


### PR DESCRIPTION
## Context
Add redirect to security domain based on endpoint

## Changes proposed in this pull request

Redirect to vdp.security.education.gov.uk if querying "/.well-known/thanks.txt", "/thanks.txt"

## Guidance to review
Test module against a review app to validate.

Validate redirects are working properly for test deployment on AYTQ for AYTQ and CTR domains

https://test.access-your-teaching-qualifications.education.gov.uk/.well-known/security.txt
https://test.access-your-teaching-qualifications.education.gov.uk/.well-known/thanks.txt

https://test.access-your-teaching-qualifications.education.gov.uk/security.txt
https://test.access-your-teaching-qualifications.education.gov.uk/thanks.txt

**With uppercase -> redirect transform in place on ruleset**

https://test.access-your-teaching-qualifications.education.gov.uk/.well-known/sEcuriTY.txt
https://test.access-your-teaching-qualifications.education.gov.uk/.well-known/THANKS.txt

https://test.access-your-teaching-qualifications.education.gov.uk/sEcuriTY.txt
https://test.access-your-teaching-qualifications.education.gov.uk/THANKS.txt

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
