### PR TITLE
[2115] Make create database optional

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -120,7 +120,7 @@ resource "azurerm_postgresql_flexible_server_configuration" "connection_throttli
 }
 
 resource "azurerm_postgresql_flexible_server_database" "main" {
-  count = var.use_azure ? 1 : 0
+  count = var.use_azure && var.create_database ? 1 : 0
 
   name      = local.database_name
   server_id = azurerm_postgresql_flexible_server.main[0].id
@@ -316,9 +316,12 @@ resource "kubernetes_deployment" "main" {
             name  = "POSTGRES_PASSWORD"
             value = local.database_password
           }
-          env {
-            name  = "POSTGRES_DB"
-            value = local.database_name
+          dynamic "env" {
+            for_each = var.create_database ? [1] : []
+            content {
+              name  = "POSTGRES_DB"
+              value = local.database_name
+            }
           }
         }
       }

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -63,6 +63,7 @@ No modules.
 | <a name="input_azure_storage_threshold"></a> [azure\_storage\_threshold](#input\_azure\_storage\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br/>    resource_group_name = string,<br/>    resource_prefix     = string,<br/>    dns_zone_prefix     = optional(string),<br/>    cpu_min             = number<br/>  })</pre> | n/a | yes |
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
+| <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Create default database. If the app creates the database instead of this module, set to false. Default: true | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -151,3 +151,9 @@ variable "azure_enable_backup_storage" {
   nullable = false
   default  = true
 }
+
+variable "create_database" {
+  default     = true
+  nullable    = false
+  description = "Create default database. If the app creates the database instead of this module, set to false. Default: true"
+}


### PR DESCRIPTION
## Context
It is useful to let the app create the database in some cases, for instance to allow rails db:prepare to work

## Changes proposed in this pull request
Make create database optional for azure DB and container DB

## Guidance to review
See https://github.com/DFE-Digital/schools-experience/pull/3308

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
