### PR TITLE
[2130] Add description to Google service account

### DIFF
--- a/aks/dfe_analytics/resources.tf
+++ b/aks/dfe_analytics/resources.tf
@@ -1,6 +1,7 @@
 resource "google_service_account" "appender" {
   account_id   = "appender-${var.service_short}-${var.environment}"
   display_name = "Service Account appender to ${var.service_short} in ${var.environment} environment"
+  description  = "Configured with workflow identity federation from Azure"
 }
 
 resource "google_service_account_iam_binding" "appender" {


### PR DESCRIPTION
## Context
When the module is used with existing google resources, the old service accounts remain. It would be helpful to add an explicit description to the new service accounts to identify them correctly.

## Changes proposed in this pull request
Add description to service accounts

## Guidance to review
Tested in https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2493
Check service account in GCP

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
