### PR TITLE
[2134] Create DNS zones having multiple values TXT records

### DIFF
--- a/dns/records/tfdocs.md
+++ b/dns/records/tfdocs.md
@@ -24,7 +24,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_credentials"></a> [azure\_credentials](#input\_azure\_credentials) | n/a | `any` | `null` | no |
 | <a name="input_hosted_zone"></a> [hosted\_zone](#input\_hosted\_zone) | n/a | `map(any)` | `{}` | no |
 
 ## Outputs

--- a/dns/records/variables.tf
+++ b/dns/records/variables.tf
@@ -1,11 +1,4 @@
-
-variable "azure_credentials" { default = null }
-
 variable "hosted_zone" {
   type    = map(any)
   default = {}
-}
-
-locals {
-  azure_credentials = try(jsondecode(var.azure_credentials), null)
 }

--- a/dns/zones/tfdocs.md
+++ b/dns/zones/tfdocs.md
@@ -26,7 +26,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_azure_credentials"></a> [azure\_credentials](#input\_azure\_credentials) | n/a | `any` | `null` | no |
 | <a name="input_hosted_zone"></a> [hosted\_zone](#input\_hosted\_zone) | n/a | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | `null` | no |
 

--- a/dns/zones/tfdocs.md
+++ b/dns/zones/tfdocs.md
@@ -18,6 +18,7 @@ No modules.
 |------|------|
 | [azurerm_dns_caa_record.caa_record_list](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
 | [azurerm_dns_caa_record.caa_records](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_caa_record) | resource |
+| [azurerm_dns_txt_record.txt_record_list](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
 | [azurerm_dns_txt_record.txt_records](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
 | [azurerm_dns_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_zone) | resource |
 

--- a/dns/zones/variables.tf
+++ b/dns/zones/variables.tf
@@ -1,6 +1,4 @@
 
-variable "azure_credentials" { default = null }
-
 variable "hosted_zone" {
   type    = map(any)
   default = {}
@@ -8,8 +6,4 @@ variable "hosted_zone" {
 
 variable "tags" {
   default = null
-}
-
-locals {
-  azure_credentials = try(jsondecode(var.azure_credentials), null)
 }


### PR DESCRIPTION
## Context
It is sometimes required to create TXT records with multiple values for the same record name

## Changes proposed in this pull request
Add txt_record_list option

## Guidance to review
Tested in https://github.com/DFE-Digital/teacher-services-cloud/pull/314

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
