### PR TITLE
[2124] Reduce length of Bigquery service account name

### DIFF
--- a/aks/dfe_analytics/resources.tf
+++ b/aks/dfe_analytics/resources.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "appender" {
-  account_id   = "appender-wif-${var.service_short}-${var.environment}"
+  account_id   = "app-wif-${var.service_short}-${var.environment}"
   display_name = "Service Account appender to ${var.service_short} in ${var.environment} environment"
   description  = "Configured with workflow identity federation from Azure"
 }


### PR DESCRIPTION
## Context
Fix for error in TRS preprod:
```
Error: "account_id" ("appender-wif-trs-pre-production") doesn't match regexp "^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$"
```

## Changes proposed in this pull request
Change the service account name to allow longer environment names

## Guidance to review
Run terraform plan on https://github.com/DFE-Digital/teaching-record-system/pull/1681

```
  # module.dfe_analytics[0].google_service_account.appender will be created
  + resource "google_service_account" "appender" {
      + account_id   = "app-wif-trs-pre-production"
      + description  = "Configured with workflow identity federation from Azure"
      + disabled     = false
      + display_name = "Service Account appender to trs in pre-production environment"
  ...
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
