### PR TITLE
[2171] Remove leading slash in URL redirect

### DIFF
--- a/domains/environment_domains/front_door_security_rules.tf
+++ b/domains/environment_domains/front_door_security_rules.tf
@@ -16,7 +16,7 @@ resource "azurerm_cdn_frontdoor_rule" "security_txt" {
   conditions {
     url_path_condition {
       operator     = "BeginsWith"
-      match_values = ["/.well-known/security.txt", "/security.txt"]
+      match_values = [".well-known/security.txt", "security.txt"]
       transforms   = ["Lowercase"]
     }
   }
@@ -43,7 +43,7 @@ resource "azurerm_cdn_frontdoor_rule" "thanks_txt" {
   conditions {
     url_path_condition {
       operator     = "BeginsWith"
-      match_values = ["/.well-known/thanks.txt", "/thanks.txt"]
+      match_values = [".well-known/thanks.txt", "thanks.txt"]
       transforms   = ["Lowercase"]
     }
   }


### PR DESCRIPTION
## Context
The [url_path_condition doc](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/cdn_frontdoor_rule#match_values-14) recommends against it

## Changes proposed in this pull request
Remove the leading slash in the matched strings

## Guidance to review
Tested on Register QA:
https://qa.register-trainee-teachers.service.gov.uk/security.txt
https://qa.register-trainee-teachers.service.gov.uk/.well-known/security.txt
https://qa.register-trainee-teachers.service.gov.uk/.well-known/thanks.txt
https://qa.register-trainee-teachers.service.gov.uk/thanks.txt

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
