### PR TITLE
[2179] Implement pod run_as_user

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -180,6 +180,9 @@ resource "kubernetes_deployment" "main" {
             capabilities {
               drop = ["ALL"]
             }
+
+            run_as_user  = var.run_as_user
+            run_as_group = var.run_as_group
           }
         }
       }

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -51,6 +51,8 @@ No modules.
 | <a name="input_probe_command"></a> [probe\_command](#input\_probe\_command) | Command for the liveness and startup probe | `list(string)` | `[]` | no |
 | <a name="input_probe_path"></a> [probe\_path](#input\_probe\_path) | Path for the liveness and startup probe. The probe can be disabled by setting this to null. | `string` | `"/healthcheck"` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of application instances | `number` | `1` | no |
+| <a name="input_run_as_group"></a> [run\_as\_group](#input\_run\_as\_group) | GID of user running the process in the container | `string` | `null` | no |
+| <a name="input_run_as_user"></a> [run\_as\_user](#input\_run\_as\_user) | UID of user running the process in the container | `string` | `null` | no |
 | <a name="input_send_traffic_to_maintenance_page"></a> [send\_traffic\_to\_maintenance\_page](#input\_send\_traffic\_to\_maintenance\_page) | During a maintenance operation, keep sending traffic to the maintenance page instead of resetting the ingress | `bool` | `false` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | `null` | no |

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -167,3 +167,17 @@ variable "enable_gcp_wif" {
   description = "Let the deployment use the GCP workload identity federation service account to get a token"
   nullable    = false
 }
+
+variable "run_as_user" {
+  type        = string
+  default     = null
+  description = "UID of user running the process in the container"
+  nullable    = true
+}
+
+variable "run_as_group" {
+  type        = string
+  default     = null
+  description = "GID of user running the process in the container"
+  nullable    = true
+}


### PR DESCRIPTION
## Context
Required to run container processes with a non-root user

## Changes proposed in this pull request
Add run_as_user and run_as_group variables

## Guidance to review
Test with hedgedoc. See https://github.com/DFE-Digital/teacher-services-hedgedoc/pull/6

## After merging
Update reference in https://github.com/DFE-Digital/teacher-services-hedgedoc/pull/6

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
