### PR TITLE
[2178] Fix postgres container image version

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -294,7 +294,7 @@ resource "kubernetes_deployment" "main" {
         }
         container {
           name  = local.kubernetes_name
-          image = var.server_docker_image
+          image = local.server_docker_image
           resources {
             requests = {
               cpu    = var.cluster_configuration_map.cpu_min

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -67,7 +67,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
-| <a name="input_server_docker_image"></a> [server\_docker\_image](#input\_server\_docker\_image) | Database image to use with kubernetes deployment, eg. postgis/postgis:16-3.4 | `string` | `"postgres:16-alpine"` | no |
+| <a name="input_server_docker_image"></a> [server\_docker\_image](#input\_server\_docker\_image) | Docker Hub image for the kubernetes deployment, eg. postgis/postgis:16-3.5. Default is postgres:<server\_version>-alpine | `string` | `null` | no |
 | <a name="input_server_version"></a> [server\_version](#input\_server\_version) | Version of PostgreSQL server | `string` | `"16"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -52,9 +52,8 @@ variable "cluster_configuration_map" {
 
 variable "server_docker_image" {
   type        = string
-  nullable    = false
-  default     = "postgres:16-alpine"
-  description = "Database image to use with kubernetes deployment, eg. postgis/postgis:16-3.4"
+  default     = null
+  description = "Docker Hub image for the kubernetes deployment, eg. postgis/postgis:16-3.5. Default is postgres:<server_version>-alpine"
 }
 
 variable "server_version" {
@@ -156,4 +155,8 @@ variable "create_database" {
   default     = true
   nullable    = false
   description = "Create default database. If the app creates the database instead of this module, set to false. Default: true"
+}
+
+locals {
+  server_docker_image = var.server_docker_image == null ? "postgres:${var.server_version}-alpine" : var.server_docker_image
 }


### PR DESCRIPTION
## Context
The default postgres container image had a harcoded version number

## Changes proposed in this pull request
Use var.server_version by default

## Guidance to review
Tested in https://github.com/DFE-Digital/itt-mentor-services/pull/1226

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
