### PR TITLE
[2182] Allow null value in config map

### DIFF
--- a/aks/application_configuration/resources.tf
+++ b/aks/application_configuration/resources.tf
@@ -10,7 +10,7 @@ locals {
     var.config_variables,
   )
 
-  config_map_hash = sha1(join("-", [for k, v in local.config_map_data : "${k}:${v}"]))
+  config_map_hash = sha1(join("-", [for k, v in local.config_map_data : "${k}:${v}" if v != null]))
 }
 
 resource "kubernetes_config_map" "main" {


### PR DESCRIPTION
## Context
Fix for error: https://github.com/DFE-Digital/get-into-teaching-app/actions/runs/12253181382/job/34182474422
The current workaround is to provide a non-null value: https://github.com/DFE-Digital/get-into-teaching-app/pull/4417

## Changes proposed in this pull request
Ignore the null variable when calculating hash. We use the same behaviour for secrets

## Guidance to review
Test before applying https://github.com/DFE-Digital/get-into-teaching-app/pull/4417

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
