### PR TITLE
[2183] Allow 1 character custom domains length

### DIFF
--- a/domains/environment_domains/front_door.tf
+++ b/domains/environment_domains/front_door.tf
@@ -33,7 +33,7 @@ resource "azurerm_cdn_frontdoor_origin" "main" {
 
 resource "azurerm_cdn_frontdoor_custom_domain" "main" {
   for_each                 = toset(var.domains)
-  name                     = replace(each.key, ".", "-")
+  name                     = length(each.key) > 1 ? replace(each.key, ".", "-") : "${replace(each.key, ".", "-")}-domain"
   cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
   dns_zone_id              = data.azurerm_dns_zone.main.id
   host_name                = startswith(each.key, "apex") ? var.zone : "${each.key}.${var.zone}"

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -40,7 +40,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cached_paths"></a> [cached\_paths](#input\_cached\_paths) | List of path patterns such as /packs/* that front door will cache | `list(string)` | `[]` | no |
-| <a name="input_domains"></a> [domains](#input\_domains) | List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use | `any` | n/a | yes |
+| <a name="input_domains"></a> [domains](#input\_domains) | List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use.<br/>    The length of "<domain>.<zone>" cannot exceed 64 characters. | `any` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | n/a | `any` | n/a | yes |
 | <a name="input_exclude_cnames"></a> [exclude\_cnames](#input\_exclude\_cnames) | Don't create the CNAME for this record from var.domains. We set this when we want to configure front door for a services domain that we are migrating so we do not need to wait for the certificate to validate and front door to propagate the configuration. | `list` | `[]` | no |
 | <a name="input_front_door_name"></a> [front\_door\_name](#input\_front\_door\_name) | n/a | `any` | n/a | yes |

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -3,7 +3,8 @@ variable "front_door_name" {}
 variable "resource_group_name" {}
 variable "domains" {
   description = <<EOF
-    List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use
+    List of subdomains of the zone e.g. "staging". For apex domain use "apex" or "apex<something>" if apex is already in use.
+    The length of "<domain>.<zone>" cannot exceed 64 characters.
   EOF
 }
 variable "environment" {}


### PR DESCRIPTION
## Context
The name of the custom domain in front door is the same as the subdomain. Subdomain with 1 character is allowed but not the custom domain name.
This is required as the length of "<domain>.<zone>" cannot exceed 64 characters and some subdomains must be 1 character to fit in.

## Changes proposed in this pull request
Add a fix to create a longer name when the subdomain is 1 character.

## Guidance to review
Implemented in https://github.com/DFE-Digital/npq-registration/pull/2070

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
