### PR TITLE
[2151] Allow github actions OIDC authentication to AKS clusters

### DIFF
--- a/aks/cluster_data/README.md
+++ b/aks/cluster_data/README.md
@@ -13,11 +13,8 @@ module "cluster_data" {
   name   = var.cluster
 }
 
-provider "kubernetes" {
-  host                   = module.cluster_data.kubernetes_host
-  client_certificate     = module.cluster_data.kubernetes_client_certificate
-  client_key             = module.cluster_data.kubernetes_client_key
-  cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+locals {
+  web_app_aks_domain = "teaching-vacancies-${var.environment}.${module.cluster_data.ingress_domain}"
 }
 ```
 
@@ -52,7 +49,7 @@ The client certificate to use to connect to the Kubernetes cluster. `null` when 
 
 The client key to use to connect to the Kubernetes cluster. `null` when the cluster uses Azure RBAC.
 
-### `kubenetes_cluster_ca_certificate`
+### `kubernetes_cluster_ca_certificate`
 
 The client cluster CA certificate to use to connect to the Kubernetes cluster.
 
@@ -64,23 +61,25 @@ The client cluster CA certificate to use to connect to the Kubernetes cluster.
 
 Arguments for [kubelogin](https://azure.github.io/kubelogin/) to authenticate to a cluster using Azure RBAC. Used in the kubernetes provider configuration:
 
-```hcl
+```terraform
 provider "kubernetes" {
   host                   = module.cluster_data.kubernetes_host
-  client_certificate     = module.cluster_data.kubernetes_client_certificate
-  client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
 
-  dynamic "exec" {
-    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
-    content {
-      api_version = "client.authentication.k8s.io/v1beta1"
-      command     = "kubelogin"
-      args        = module.cluster_data.kubelogin_args
-    }
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "kubelogin"
+    args        = module.cluster_data.kubelogin_args
   }
 }
 ```
+
+Supports 3 kubelogin authentication modes:
+- `azurecli` when running locally
+- `spn` when running in Github actions using an Azure service principal secret (deprecated)
+- `workloadidentity` when running in Github actions using OIDC (preferred)
+
+The mode is automatically selected based on standard environment variables.
 
 ### `ingress_domain`
 
@@ -89,4 +88,4 @@ Generic domain for all web applications on the cluster.
 For example the test cluster ingress domain is "test.teacherservices.cloud". The web application apply-review-1234 full domain is:
 
 `<app name>.<ingress domain>` or
-"apply-review-1234.test.teacherservices.cloud"
+`apply-review-1234.test.teacherservices.cloud`

--- a/aks/cluster_data/data.tf
+++ b/aks/cluster_data/data.tf
@@ -17,3 +17,8 @@ terraform {
 data "environment_variables" "github_actions" {
   filter = "GITHUB_ACTIONS"
 }
+
+data "environment_variables" "spn_secret" {
+  filter    = "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET"
+  sensitive = true
+}

--- a/aks/cluster_data/outputs.tf
+++ b/aks/cluster_data/outputs.tf
@@ -31,7 +31,15 @@ output "ingress_domain" {
 }
 
 output "kubelogin_args" {
-  value = local.spn_authentication ? local.kubelogin_args_map["spn"] : local.kubelogin_args_map["azurecli"]
+  description = "Kubelogin arguments to use configure the kubernetes provider. Allows workload identity, service principal secret and azure cli"
+  # If running in github actions, use either spn secret authentication or workload identity. If not, use azure cli.
+  value = (local.running_in_github_actions ? (
+    local.using_spn_secret ?
+    local.kubelogin_args_map["spn"] :
+    local.kubelogin_args_map["workloadidentity"]
+    ) :
+    local.kubelogin_args_map["azurecli"]
+  )
 }
 output "azure_RBAC_enabled" {
   value = local.azure_RBAC_enabled

--- a/aks/cluster_data/tfdocs.md
+++ b/aks/cluster_data/tfdocs.md
@@ -22,6 +22,7 @@ No modules.
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [environment_variables.github_actions](https://registry.terraform.io/providers/EppO/environment/1.3.5/docs/data-sources/variables) | data source |
+| [environment_variables.spn_secret](https://registry.terraform.io/providers/EppO/environment/1.3.5/docs/data-sources/variables) | data source |
 
 ## Inputs
 
@@ -36,7 +37,7 @@ No modules.
 | <a name="output_azure_RBAC_enabled"></a> [azure\_RBAC\_enabled](#output\_azure\_RBAC\_enabled) | n/a |
 | <a name="output_configuration_map"></a> [configuration\_map](#output\_configuration\_map) | n/a |
 | <a name="output_ingress_domain"></a> [ingress\_domain](#output\_ingress\_domain) | n/a |
-| <a name="output_kubelogin_args"></a> [kubelogin\_args](#output\_kubelogin\_args) | n/a |
+| <a name="output_kubelogin_args"></a> [kubelogin\_args](#output\_kubelogin\_args) | Kubelogin arguments to use configure the kubernetes provider. Allows workload identity, service principal secret and azure cli |
 | <a name="output_kubernetes_client_certificate"></a> [kubernetes\_client\_certificate](#output\_kubernetes\_client\_certificate) | n/a |
 | <a name="output_kubernetes_client_key"></a> [kubernetes\_client\_key](#output\_kubernetes\_client\_key) | n/a |
 | <a name="output_kubernetes_cluster_ca_certificate"></a> [kubernetes\_cluster\_ca\_certificate](#output\_kubernetes\_cluster\_ca\_certificate) | n/a |

--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -90,10 +90,20 @@ locals {
       "azurecli",
       "--server-id",
       "6dae42f8-4368-4678-94ff-3960e28e3630"
+    ],
+    workloadidentity = [
+      "get-token",
+      "--login",
+      "workloadidentity",
+      "--tenant-id",
+      data.azurerm_client_config.current.tenant_id,
+      "--server-id",
+      "6dae42f8-4368-4678-94ff-3960e28e3630"
     ]
   }
 
   azure_RBAC_enabled = length(data.azurerm_kubernetes_cluster.main.azure_active_directory_role_based_access_control) > 0
 
-  spn_authentication = contains(keys(data.environment_variables.github_actions.items), "GITHUB_ACTIONS")
+  running_in_github_actions = contains(keys(data.environment_variables.github_actions.items), "GITHUB_ACTIONS")
+  using_spn_secret          = contains(keys(data.environment_variables.spn_secret.items), "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET")
 }


### PR DESCRIPTION
## Context
Update kubelogin arguments to use OIDC instead of service principal secret

## Changes proposed in this pull request
Update kubelogin arguments

## Guidance to review
See https://github.com/DFE-Digital/itt-mentor-services/pull/1253

## After merging
Update https://github.com/DFE-Digital/itt-mentor-services/pull/1253 to point at main

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
