### PR TITLE
[2151] Simplify kubelogin arguments

### DIFF
--- a/aks/cluster_data/data.tf
+++ b/aks/cluster_data/data.tf
@@ -17,8 +17,3 @@ terraform {
 data "environment_variables" "github_actions" {
   filter = "GITHUB_ACTIONS"
 }
-
-data "environment_variables" "spn_secret" {
-  filter    = "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET"
-  sensitive = true
-}

--- a/aks/cluster_data/outputs.tf
+++ b/aks/cluster_data/outputs.tf
@@ -32,13 +32,11 @@ output "ingress_domain" {
 
 output "kubelogin_args" {
   description = "Kubelogin arguments to use configure the kubernetes provider. Allows workload identity, service principal secret and azure cli"
-  # If running in github actions, use either spn secret authentication or workload identity. If not, use azure cli.
-  value = (local.running_in_github_actions ? (
-    local.using_spn_secret ?
-    local.kubelogin_args_map["spn"] :
-    local.kubelogin_args_map["workloadidentity"]
-    ) :
-    local.kubelogin_args_map["azurecli"]
+  # If running in github actions, AAD_LOGIN_METHOD determines the login method, either workloadidentity or spn
+  # If not, use azurecli explicitly as command line argument
+  value = (local.running_in_github_actions ?
+    local.kubelogin_github_actions_args :
+    local.kubelogin_azurecli_args
   )
 }
 output "azure_RBAC_enabled" {

--- a/aks/cluster_data/tfdocs.md
+++ b/aks/cluster_data/tfdocs.md
@@ -22,7 +22,6 @@ No modules.
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [environment_variables.github_actions](https://registry.terraform.io/providers/EppO/environment/1.3.5/docs/data-sources/variables) | data source |
-| [environment_variables.spn_secret](https://registry.terraform.io/providers/EppO/environment/1.3.5/docs/data-sources/variables) | data source |
 
 ## Inputs
 

--- a/aks/cluster_data/variables.tf
+++ b/aks/cluster_data/variables.tf
@@ -72,38 +72,19 @@ locals {
   configuration_map                 = local.configuration_maps[var.name]
   dns_zone_prefix_with_optional_dot = local.configuration_map.dns_zone_prefix == null ? "" : "${local.configuration_map.dns_zone_prefix}."
 
-  kubelogin_args_map = {
-    spn = [
-      "get-token",
-      "--login",
-      "spn",
-      "--environment",
-      "AzurePublicCloud",
-      "--tenant-id",
-      data.azurerm_client_config.current.tenant_id,
-      "--server-id",
-      "6dae42f8-4368-4678-94ff-3960e28e3630" # See https://azure.github.io/kubelogin/concepts/aks.html
-    ],
-    azurecli = [
-      "get-token",
-      "--login",
-      "azurecli",
-      "--server-id",
-      "6dae42f8-4368-4678-94ff-3960e28e3630"
-    ],
-    workloadidentity = [
-      "get-token",
-      "--login",
-      "workloadidentity",
-      "--tenant-id",
-      data.azurerm_client_config.current.tenant_id,
-      "--server-id",
-      "6dae42f8-4368-4678-94ff-3960e28e3630"
-    ]
-  }
+  kubelogin_github_actions_args = [
+    "get-token",
+    "--server-id",
+    "6dae42f8-4368-4678-94ff-3960e28e3630" # See https://azure.github.io/kubelogin/concepts/aks.html
+  ]
+  kubelogin_azurecli_args = [
+    "get-token",
+    "--login",
+    "azurecli",
+    "--server-id",
+    "6dae42f8-4368-4678-94ff-3960e28e3630"
+  ]
+  running_in_github_actions = contains(keys(data.environment_variables.github_actions.items), "GITHUB_ACTIONS")
 
   azure_RBAC_enabled = length(data.azurerm_kubernetes_cluster.main.azure_active_directory_role_based_access_control) > 0
-
-  running_in_github_actions = contains(keys(data.environment_variables.github_actions.items), "GITHUB_ACTIONS")
-  using_spn_secret          = contains(keys(data.environment_variables.spn_secret.items), "AAD_SERVICE_PRINCIPAL_CLIENT_SECRET")
 }


### PR DESCRIPTION
## Context
The logic introduced for OIDC was overly complicated

Depends on https://github.com/DFE-Digital/github-actions/pull/106

## Changes proposed in this pull request
Make use of AAD_LOGIN_METHOD environment variable instead of command line arguments

## Guidance to review
See https://github.com/DFE-Digital/itt-mentor-services/pull/1281

## After merging
Update references to oidc-ga in https://github.com/DFE-Digital/itt-mentor-services/pull/1281

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
