### PR TITLE
[2200] Pin postgres and redis to the application node pool

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -290,7 +290,8 @@ resource "kubernetes_deployment" "main" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
         }
         container {
           name  = local.kubernetes_name

--- a/aks/redis/resources.tf
+++ b/aks/redis/resources.tf
@@ -141,7 +141,8 @@ resource "kubernetes_deployment" "main" {
       }
       spec {
         node_selector = {
-          "kubernetes.io/os" : "linux"
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
         }
         container {
           name  = local.kubernetes_name


### PR DESCRIPTION
## Context
The default node pool is reserved for the system. User apps should be deployed to the apps1 node pool.

## Changes proposed in this pull request
Use the node_selector to pin the pods to the application node pool

## Guidance to review
Used in ITTMS PR: https://github.com/DFE-Digital/itt-mentor-services/pull/1300

Check all pods are deployed to the apps1 node pool:
```
 kubectl get pods -A -o wide | grep itt-mentor-services-1300
```

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
