### PR TITLE
[2214] Front door rate limiting

### DIFF
--- a/domains/environment_domains/rate_limit.tf
+++ b/domains/environment_domains/rate_limit.tf
@@ -1,0 +1,50 @@
+resource "azurerm_cdn_frontdoor_firewall_policy" "rate_limit" {
+  count = var.rate_limit != null ? 1 : 0
+
+  name                              = "${var.environment}RateLimitFirewallPolicy"
+  resource_group_name               = var.resource_group_name
+  sku_name                          = data.azurerm_cdn_frontdoor_profile.main.sku_name
+  mode                              = "Prevention"
+  custom_block_response_status_code = 429
+
+  custom_rule {
+    name                           = "${var.environment}RateLimit${var.rate_limit}"
+    rate_limit_duration_in_minutes = 5
+    rate_limit_threshold           = var.rate_limit
+    type                           = "RateLimitRule"
+    action                         = "Block"
+
+    # This match condition must match all requests (Host header size is not zero)
+    match_condition {
+      match_variable = "RequestHeader"
+      selector       = "Host"
+      operator       = "GreaterThanOrEqual"
+      match_values   = ["0"]
+    }
+  }
+
+  lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_cdn_frontdoor_security_policy" "rate_limit" {
+  count = var.rate_limit != null ? 1 : 0
+
+  name                     = "${var.environment}RateLimitSecurityPolicy"
+  cdn_frontdoor_profile_id = data.azurerm_cdn_frontdoor_profile.main.id
+
+  security_policies {
+    firewall {
+      cdn_frontdoor_firewall_policy_id = azurerm_cdn_frontdoor_firewall_policy.rate_limit[0].id
+
+      association {
+        dynamic "domain" {
+          for_each = toset(var.domains)
+          content {
+            cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.main[domain.key].id
+          }
+        }
+        patterns_to_match = ["/*"]
+      }
+    }
+  }
+}

--- a/domains/environment_domains/tfdocs.md
+++ b/domains/environment_domains/tfdocs.md
@@ -19,6 +19,7 @@ No modules.
 | [azurerm_cdn_frontdoor_custom_domain.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain) | resource |
 | [azurerm_cdn_frontdoor_custom_domain_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_custom_domain_association) | resource |
 | [azurerm_cdn_frontdoor_endpoint.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_endpoint) | resource |
+| [azurerm_cdn_frontdoor_firewall_policy.rate_limit](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_firewall_policy) | resource |
 | [azurerm_cdn_frontdoor_origin.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin) | resource |
 | [azurerm_cdn_frontdoor_origin_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_origin_group) | resource |
 | [azurerm_cdn_frontdoor_route.cached](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_route) | resource |
@@ -28,6 +29,7 @@ No modules.
 | [azurerm_cdn_frontdoor_rule.thanks_txt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule) | resource |
 | [azurerm_cdn_frontdoor_rule_set.redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
 | [azurerm_cdn_frontdoor_rule_set.security_redirects](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_rule_set) | resource |
+| [azurerm_cdn_frontdoor_security_policy.rate_limit](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cdn_frontdoor_security_policy) | resource |
 | [azurerm_dns_a_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_a_record) | resource |
 | [azurerm_dns_cname_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
 | [azurerm_dns_txt_record.apex](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
@@ -47,6 +49,7 @@ No modules.
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | Origin host name ie domain to where front door sends the requests. It may not be used if all requests are redirected. | `string` | `"not-in-use.education.gov.uk"` | no |
 | <a name="input_multiple_hosted_zones"></a> [multiple\_hosted\_zones](#input\_multiple\_hosted\_zones) | n/a | `bool` | `false` | no |
 | <a name="input_null_host_header"></a> [null\_host\_header](#input\_null\_host\_header) | The origin\_host\_header for the azurerm\_cdn\_frontdoor\_origin resource will be var.host\_name (if false) or null (if true). If null then the host name from the incoming request will be used. | `bool` | `false` | no |
+| <a name="input_rate_limit"></a> [rate\_limit](#input\_rate\_limit) | Number of requests per 5 minutes | `number` | `null` | no |
 | <a name="input_redirect_rules"></a> [redirect\_rules](#input\_redirect\_rules) | List of ordered redirect rules with format:<br/>    [<br/>      {<br/>        "from-domain": "One of the domains from var.domains to redirect from",<br/>        "to-domain": "Redirect destination domain",<br/>        "to-path": "Optional path appended to the destination URL. If not provided, the path will be the same as in the incoming request",<br/>        "to-query-string": "Optional path appended to the destination URL. If not provided, defaults to empty string"<br/>      },<br/>      {<br/>        ...<br/>      }<br/>    ] | `list(any)` | `[]` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `any` | n/a | yes |
 | <a name="input_rule_set_ids"></a> [rule\_set\_ids](#input\_rule\_set\_ids) | n/a | `list(any)` | `[]` | no |

--- a/domains/environment_domains/variables.tf
+++ b/domains/environment_domains/variables.tf
@@ -62,3 +62,9 @@ variable "redirect_rules" {
     ]
   EOF
 }
+
+variable "rate_limit" {
+  type        = number
+  default     = null
+  description = "Number of requests per 5 minutes"
+}


### PR DESCRIPTION
## Context
Create a rate limit per environment to prevent from denial of service attacks

## Changes proposed in this pull request
Introduce the rate_limit variable in the environment_domains module to create a firewall policy with a rate limit custom rule

## Guidance to review
Implemented in branch 2214-front-door-rate-limiting of https://github.com/DFE-Digital/teacher-pay-calculator/
Applied to front door s189p01-ctp-domains-fd
You can test with Azure load testing: s189p01-ctp-lt

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
