### PR TITLE
fix rate limit for multiple zones

### DIFF
--- a/domains/environment_domains/locals.tf
+++ b/domains/environment_domains/locals.tf
@@ -5,6 +5,7 @@ locals {
   # If false, removes anything after the first full stop/period e.g. 'domain.education.gov.uk' becomes just 'domain'.
   short_zone_name    = substr(replace(var.zone, "/^[^.]+\\./", ""), 0, 3)
   endpoint_zone_name = var.multiple_hosted_zones ? replace(var.zone, "/\\..+$/", "-${local.short_zone_name}") : replace(var.zone, "/\\..+$/", "")
+  short_policy_name  = substr(local.endpoint_zone_name, 0, 3)
 
   cached_domain_list = length(var.cached_paths) > 0 ? var.domains : []
 

--- a/domains/environment_domains/rate_limit.tf
+++ b/domains/environment_domains/rate_limit.tf
@@ -1,7 +1,7 @@
 resource "azurerm_cdn_frontdoor_firewall_policy" "rate_limit" {
   count = length(var.rate_limit) > 0 ? 1 : 0
 
-  name                              = "${var.environment}RateLimitFirewallPolicy"
+  name                              = "${local.short_policy_name}${var.environment}RateLimitFirewallPolicy"
   resource_group_name               = var.resource_group_name
   sku_name                          = data.azurerm_cdn_frontdoor_profile.main.sku_name
   mode                              = "Prevention"


### PR DESCRIPTION
## Context

Adding rate limit firewall policy resources for environment domains fail if multiple zones are in the same service.
This is due to trying to create multiple policies with the same name.

## Changes proposed in this pull request
Add a short prefix based on the first 3 letters of the zone and use this is the firewall policy name

## Guidance to review
deploy plan against this branch
Have run this from git, afqts and aytq.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
