### PR TITLE
Add override for job create/update timeout

### DIFF
--- a/aks/job_configuration/resources.tf
+++ b/aks/job_configuration/resources.tf
@@ -73,7 +73,7 @@ resource "kubernetes_job" "main" {
   wait_for_completion = true
 
   timeouts {
-    create = "11m"
-    update = "11m"
+    create = var.timeout
+    update = var.timeout
   }
 }

--- a/aks/job_configuration/tfdocs.md
+++ b/aks/job_configuration/tfdocs.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | AKS namespace where this app is deployed | `any` | n/a | yes |
 | <a name="input_secret_ref"></a> [secret\_ref](#input\_secret\_ref) | formerly: module.application\_configuration.kubernetes\_secret\_name | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service. Usually the same as the repo name | `any` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Create and update timeout for job | `string` | `"15m"` | no |
 
 ## Outputs
 

--- a/aks/job_configuration/variables.tf
+++ b/aks/job_configuration/variables.tf
@@ -57,3 +57,9 @@ variable "max_memory" {
   default     = "1Gi"
   description = "Maximum memory of the instance"
 }
+
+variable "timeout" {
+  type        = string
+  default     = "15m"
+  description = "Create and update timeout for job"
+}


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
<!-- Why are we making this change? New feature? Bug fix? -->
Some jobs take longer to create than the current 11 minutes and may fail during creation. 

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->
Provide a timeout override in the job configuration

## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->
Check the implementation here -https://github.com/DFE-Digital/teaching-record-system/actions/runs/15610296200/job/43971074509?pr=2085

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
