### PR TITLE
Allow different rate limit rules in domains module

### DIFF
--- a/domains/environment_domains/rate_limit.tf
+++ b/domains/environment_domains/rate_limit.tf
@@ -12,15 +12,16 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "rate_limit" {
     content {
       name                           = custom_rule.value["agent"]
       priority                       = custom_rule.value["priority"]
+      enabled                        = try(custom_rule.value["enabled"], "true")
       rate_limit_duration_in_minutes = custom_rule.value["duration"]
       rate_limit_threshold           = custom_rule.value["limit"]
-      type                           = "RateLimitRule"
-      action                         = "Block"
+      type                           = try(custom_rule.value["type"], "RateLimitRule")
+      action                         = try(custom_rule.value["action"], "Block")
 
       # To match all requests use Host header size is not zero
       match_condition {
-        match_variable = "RequestHeader"
-        selector       = custom_rule.value["selector"]
+        match_variable = try(custom_rule.value["match_variable"], "RequestHeader")
+        selector       = try(custom_rule.value["selector"], "")
         operator       = custom_rule.value["operator"]
         match_values   = ["${custom_rule.value["match_values"]}"]
       }


### PR DESCRIPTION
## Context
Currently the domain rate limiting only allows a subset of rate limiting rules, i.e. ratelimitrule/requestheader
We want to allow all rule types to be added.

## Changes proposed in this pull request
Update the rate limit terraform to allow setting all rule options
Set original defaults for new options so that existing configs don't need to be changed or fail

## Guidance to review

point services to this branch and test 
- in git 
make test domains-plan (should show no change)
- in ptt PR nn
make qa pubish-domains-plan (should add new rules)

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
