### PR TITLE
Add support for non-root in application module

### DIFF
--- a/aks/application/resources.tf
+++ b/aks/application/resources.tf
@@ -181,8 +181,9 @@ resource "kubernetes_deployment" "main" {
               drop = ["ALL"]
             }
 
-            run_as_user  = var.run_as_user
-            run_as_group = var.run_as_group
+            run_as_user     = var.run_as_user
+            run_as_group    = var.run_as_group
+            run_as_non_root = var.run_as_non_root
           }
         }
       }

--- a/aks/application/tfdocs.md
+++ b/aks/application/tfdocs.md
@@ -52,6 +52,7 @@ No modules.
 | <a name="input_probe_path"></a> [probe\_path](#input\_probe\_path) | Path for the liveness and startup probe. The probe can be disabled by setting this to null. | `string` | `"/healthcheck"` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of application instances | `number` | `1` | no |
 | <a name="input_run_as_group"></a> [run\_as\_group](#input\_run\_as\_group) | GID of user running the process in the container | `string` | `null` | no |
+| <a name="input_run_as_non_root"></a> [run\_as\_non\_root](#input\_run\_as\_non\_root) | Whether to enforce that containers must run as non-root user | `bool` | `false` | no |
 | <a name="input_run_as_user"></a> [run\_as\_user](#input\_run\_as\_user) | UID of user running the process in the container | `string` | `null` | no |
 | <a name="input_send_traffic_to_maintenance_page"></a> [send\_traffic\_to\_maintenance\_page](#input\_send\_traffic\_to\_maintenance\_page) | During a maintenance operation, keep sending traffic to the maintenance page instead of resetting the ingress | `bool` | `false` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |

--- a/aks/application/variables.tf
+++ b/aks/application/variables.tf
@@ -181,3 +181,10 @@ variable "run_as_group" {
   description = "GID of user running the process in the container"
   nullable    = true
 }
+
+variable "run_as_non_root" {
+  type        = bool
+  default     = false
+  description = "Whether to enforce that containers must run as non-root user"
+  nullable    = false
+}


### PR DESCRIPTION
  - Add run_as_non_root variable to enforce non-root user execution
  - Update security_context in kubernetes_deployment to include run_as_non_root setting
  - Update terraform-docs generated documentation
  - Enhances container security by allowing enforcement of non-root execution at Kubernetes level
  - Supports ITHC security recommendations for container hardening

<!-- Delete sections if not required -->

## Context
<!-- Why are we making this change? New feature? Bug fix? -->

## Changes proposed in this pull request
<!-- Describe briefly the technical implementation -->
<!-- Show any dependencies between pull requests, i.e. this must be merged before or after another -->

## Guidance to review
<!-- Show how this can be tested or evidence that it is working -->

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
