### PR TITLE
Configuring the monitoring for postgres logical replication

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -120,6 +120,13 @@ resource "azurerm_postgresql_flexible_server_configuration" "connection_throttli
   value     = "on"
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "wal_level" {
+  count     = var.use_azure && var.enable_logical_replication ? 1 : 0
+  name      = "wal_level"
+  server_id = azurerm_postgresql_flexible_server.main[0].id
+  value     = "logical"
+}
+
 resource "azurerm_postgresql_flexible_server_database" "main" {
   count = var.use_azure && var.create_database ? 1 : 0
 
@@ -265,6 +272,64 @@ resource "azurerm_monitor_metric_alert" "storage" {
     aggregation      = "Average"
     operator         = "GreaterThan"
     threshold        = var.azure_storage_threshold
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "txlog_storage_used" {
+  count = var.use_azure && var.enable_logical_replication ? 1 : 0
+
+  name                = "${azurerm_postgresql_flexible_server.main[0].name}-txlog-storage-used"
+  resource_group_name = data.azurerm_resource_group.main[0].name
+  scopes              = [azurerm_postgresql_flexible_server.main[0].id]
+  description         = "Action will be triggered when txlog storage use is greater than ${var.txlogs_storage_used_threshold}"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "txlogs_storage_used"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.txlogs_storage_used_threshold
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "logical_replication_lag" {
+  count = var.use_azure && var.enable_logical_replication ? 1 : 0
+
+  name                = "${azurerm_postgresql_flexible_server.main[0].name}-logical-replication-lag"
+  resource_group_name = data.azurerm_resource_group.main[0].name
+  scopes              = [azurerm_postgresql_flexible_server.main[0].id]
+  description         = "Action will be triggered when logical replication lag is greater than ${var.logical_replication_delay_in_bytes_threshold}"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.DBforPostgreSQL/flexibleServers"
+    metric_name      = "logical_replication_delay_in_bytes"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.logical_replication_delay_in_bytes_threshold
   }
 
   action {

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -21,12 +21,15 @@ No modules.
 | [azurerm_log_analytics_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
 | [azurerm_monitor_diagnostic_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_monitor_metric_alert.cpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.logical_replication_lag](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.memory](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.txlog_storage_used](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_postgresql_flexible_server.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
 | [azurerm_postgresql_flexible_server_configuration.azure_extensions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.connection_throttling](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_connections](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
+| [azurerm_postgresql_flexible_server_configuration.wal_level](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_storage_account.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
@@ -66,7 +69,9 @@ No modules.
 | <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br/>    resource_group_name = string,<br/>    resource_prefix     = string,<br/>    dns_zone_prefix     = optional(string),<br/>    cpu_min             = number<br/>  })</pre> | n/a | yes |
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
 | <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Create default database. If the app creates the database instead of this module, set to false. Default: true | `bool` | `true` | no |
+| <a name="input_enable_logical_replication"></a> [enable\_logical\_replication](#input\_enable\_logical\_replication) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
+| <a name="input_logical_replication_delay_in_bytes_threshold"></a> [logical\_replication\_delay\_in\_bytes\_threshold](#input\_logical\_replication\_delay\_in\_bytes\_threshold) | n/a | `number` | `100000000` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
 | <a name="input_server_docker_image"></a> [server\_docker\_image](#input\_server\_docker\_image) | Docker Hub image for the kubernetes deployment, eg. postgis/postgis:16-3.5. Default is postgres:<server\_version>-alpine | `string` | `null` | no |
@@ -74,6 +79,7 @@ No modules.
 | <a name="input_server_version"></a> [server\_version](#input\_server\_version) | Version of PostgreSQL server | `string` | `"16"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
+| <a name="input_txlogs_storage_used_threshold"></a> [txlogs\_storage\_used\_threshold](#input\_txlogs\_storage\_used\_threshold) | n/a | `number` | `4000` | no |
 | <a name="input_use_azure"></a> [use\_azure](#input\_use\_azure) | Whether to deploy using Azure Redis Cache service | `bool` | n/a | yes |
 
 ## Outputs

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -133,6 +133,15 @@ variable "azure_enable_monitoring" {
   default  = true
 }
 
+variable "txlogs_storage_used_threshold" {
+  type    = number
+  default = 4000
+}
+
+variable "logical_replication_delay_in_bytes_threshold" {
+  type    = number
+  default = 100000000
+}
 
 
 variable "alert_window_size" {
@@ -171,6 +180,11 @@ variable "server_docker_repo" {
   type     = string
   nullable = false
   default  = "ghcr.io/dfe-digital/teacher-services-cloud"
+}
+
+variable "enable_logical_replication" {
+  type    = bool
+  default = false
 }
 
 locals {


### PR DESCRIPTION
## Context
Configuring the monitoring for postgres logical replication

## Changes proposed in this pull request
Configuring the monitoring for postgres logical replication
## Guidance to review
Pull 2363-spike-trs-replication-monitoring-and-configuration branch on trs
Check that the additional two metric alerts for the logical replication will be created
and the wal_level logical configuration will be replaced through the postgres module
make env terraform-plan

## Checklist

- [x]  I have performed a self-review of my code, including formatting and typos
- [x]  I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x]  I have added the Devops label
- [x]  I have attached the pull request to the trello card