### PR TITLE
feat(2705): claim storage account - add private storage account 

### DIFF
--- a/aks/storage_account/README.md
+++ b/aks/storage_account/README.md
@@ -8,8 +8,12 @@ Terraform code for deploying an Azure Storage Account with the recommended best 
 
 For the list of requirement, inputs, outputs, resources... check the [terraform module documentation](tfdocs.md).
 
+
 ## Usage
 
+Both public and private storage accounts are available.
+
+A module call to create a **public** storage account is the default and would look like this:-
 ```terraform
 module "storage" {
   source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/storage_account?ref=stable"
@@ -38,6 +42,28 @@ module "storage" {
   encryption_scope_name   = "microsoftmanaged"
 }
 ```
+<br>
+
+A module call to create a **private** storage account requires 1 override:-
+
+add the following override in the above public storage account module call to convert it to private:-
+
+```
+  use_private_storage           = true
+```
+
+The private storage account would then be accessed in code by referring to its own A-name record in the private DNS zone e.g.
+```
+[storage-account-name].privatelink.blob.core.windows.net
+```
+for example:-
+```
+s189d01ittmsprivrv1900sa.privatelink.blob.core.windows.net
+```
+
+this privatelink fqdn value is available via this module output variable: **storage_private_blob_fqdn**
+
+<br>
 
 ### Storage Account Naming
 

--- a/aks/storage_account/data.tf
+++ b/aks/storage_account/data.tf
@@ -1,0 +1,23 @@
+
+data "azurerm_resource_group" "main" {
+  name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+}
+
+data "azurerm_virtual_network" "priv" {
+  count               = var.use_private_storage ? 1 : 0
+  name                = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_subnet" "priv" {
+  count                = var.use_private_storage ? 1 : 0
+  name                 = "private-storage-snet"
+  virtual_network_name = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name  = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_private_dns_zone" "priv" {
+  count               = var.use_private_storage ? 1 : 0
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
+}

--- a/aks/storage_account/outputs.tf
+++ b/aks/storage_account/outputs.tf
@@ -33,3 +33,7 @@ output "containers" {
     }
   }
 }
+
+output "storage_private_blob_fqdn" {
+  value = var.use_private_storage ? "${azurerm_storage_account.main.name}.privatelink.blob.core.windows.net" : null
+}

--- a/aks/storage_account/resources.tf
+++ b/aks/storage_account/resources.tf
@@ -3,10 +3,6 @@ locals {
   storage_account_name = "${var.azure_resource_prefix}${var.service_short}${var.name}${local.storage_account_env}sa"
 }
 
-data "azurerm_resource_group" "main" {
-  name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
-}
-
 resource "azurerm_storage_account" "main" {
   access_tier                       = "Hot"
   account_kind                      = "StorageV2"
@@ -80,4 +76,33 @@ resource "azurerm_storage_management_policy" "main" {
       }
     }
   }
+}
+
+
+resource "azurerm_private_endpoint" "storage" {
+  count = var.use_private_storage ? 1 : 0
+
+  name                = "${local.storage_account_name}-pe"
+  location            = data.azurerm_resource_group.main.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  subnet_id           = data.azurerm_subnet.priv[0].id
+
+  private_dns_zone_group {
+    name                 = data.azurerm_private_dns_zone.priv[0].name
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.priv[0].id]
+  }
+
+  private_service_connection {
+    name                           = "${local.storage_account_name}-pe"
+    private_connection_resource_id = azurerm_storage_account.main.id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+
 }

--- a/aks/storage_account/tfdocs.md
+++ b/aks/storage_account/tfdocs.md
@@ -16,11 +16,15 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_private_endpoint.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_storage_account.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.containers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_encryption_scope.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_encryption_scope) | resource |
 | [azurerm_storage_management_policy.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
+| [azurerm_private_dns_zone.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_virtual_network.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
@@ -30,6 +34,7 @@ No modules.
 | <a name="input_blob_delete_after_days"></a> [blob\_delete\_after\_days](#input\_blob\_delete\_after\_days) | Number of days after which blobs will be deleted. Set to 0 to disable automatic deletion. | `number` | `7` | no |
 | <a name="input_blob_delete_retention_days"></a> [blob\_delete\_retention\_days](#input\_blob\_delete\_retention\_days) | Number of days to retain deleted blobs. Set to null to disable retention policy. | `number` | `null` | no |
 | <a name="input_blob_versioning_enabled"></a> [blob\_versioning\_enabled](#input\_blob\_versioning\_enabled) | Enable blob versioning | `bool` | `false` | no |
+| <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the cluster | <pre>object({<br/>    resource_group_name = string,<br/>    resource_prefix     = string,<br/>    dns_zone_prefix     = optional(string),<br/>    cpu_min             = number<br/>  })</pre> | <pre>{<br/>  "cpu_min": 1,<br/>  "resource_group_name": "",<br/>  "resource_prefix": ""<br/>}</pre> | no |
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
 | <a name="input_container_delete_retention_days"></a> [container\_delete\_retention\_days](#input\_container\_delete\_retention\_days) | Number of days to retain deleted containers. Set to null to disable retention policy. | `number` | `null` | no |
 | <a name="input_containers"></a> [containers](#input\_containers) | List of containers to create on the storage account (all containers will be private) | `list(object({ name = string }))` | `[]` | no |
@@ -43,6 +48,7 @@ No modules.
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Whether public network access is allowed for the storage account | `bool` | `false` | no |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
 | <a name="input_storage_account_name_override"></a> [storage\_account\_name\_override](#input\_storage\_account\_name\_override) | Override the generated storage account name with a custom name | `string` | `null` | no |
+| <a name="input_use_private_storage"></a> [use\_private\_storage](#input\_use\_private\_storage) | Whether to deploy a private Storage Account | `bool` | `false` | no |
 
 ## Outputs
 
@@ -54,3 +60,4 @@ No modules.
 | <a name="output_primary_access_key"></a> [primary\_access\_key](#output\_primary\_access\_key) | The primary access key for the Storage Account |
 | <a name="output_primary_blob_endpoint"></a> [primary\_blob\_endpoint](#output\_primary\_blob\_endpoint) | The primary blob endpoint URL |
 | <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | The primary connection string for the Storage Account |
+| <a name="output_storage_private_blob_fqdn"></a> [storage\_private\_blob\_fqdn](#output\_storage\_private\_blob\_fqdn) | n/a |

--- a/aks/storage_account/variables.tf
+++ b/aks/storage_account/variables.tf
@@ -111,3 +111,24 @@ variable "blob_delete_after_days" {
     error_message = "The blob_delete_after_days must be between 0 and 9999. Set to 0 to disable."
   }
 }
+
+variable "cluster_configuration_map" {
+  type = object({
+    resource_group_name = string,
+    resource_prefix     = string,
+    dns_zone_prefix     = optional(string),
+    cpu_min             = number
+  })
+  description = "Configuration map for the cluster"
+  default = {
+    resource_group_name = ""
+    resource_prefix     = ""
+    cpu_min             = 1
+  }
+}
+
+variable "use_private_storage" {
+  type        = bool
+  description = "Whether to deploy a private Storage Account"
+  default     = false
+}


### PR DESCRIPTION
## Context
- tenant (CAPT) have requested a private storage account

https://trello.com/c/5aMTvHKg/2705-claim-storage-account

## Changes proposed in this pull request
- new functionality within storage module to allow configuration of a private storage account via private endpoint

## Guidance to review
- dependant networking (dedicated storage subnet and dedicated storage private dns zone) configured in a separate [PR](https://github.com/DFE-Digital/teacher-services-cloud/pull/585/changes) within tsc repo


nslookup call from itt review container to private endpoint:-
<img width="1492" height="244" alt="image" src="https://github.com/user-attachments/assets/a8749a68-2f02-403a-97bf-0bb001d2f9c4" />

<img width="1" height="4" alt="Screenshot from 2026-03-30 17-07-28" src="https://github.com/user-attachments/assets/89ee9fdc-d7dc-4f6c-ad62-1b134d5e0df8" />


## Before merging
- merge in tsc PR first (sets up dedicated storage subnet and dedicated storage private dns zone)

## After merging
- merge in PR for CAPT containing storage module call
https://github.com/DFE-Digital/claim-additional-payments-for-teaching/pull/4468/changes

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
