### PR TITLE
2740 - New Azure Managed Redis module

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -200,6 +200,26 @@ module "redis" {
 }
 ```
 
+### Azure Managed Redis
+
+```terraform
+module "redis-managed" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis-managed?ref=stable"
+
+  namespace             = var.namespace
+  environment           = local.environment
+  azure_resource_prefix = var.azure_resource_prefix
+  service_name          = local.service_name
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  use_azure               = var.deploy_azure_backing_services
+  azure_enable_monitoring = var.enable_monitoring
+}
+```
+
 ### PostgreSQL database
 
 ```terraform
@@ -307,6 +327,7 @@ Some services will require multiple Key Vaults to store application and infrastr
   - `${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-inf-kv`
 - Add `secret_key_vault_short = "app"` to the application configuration.
 - Add a secrets instance to retrieve infrastructure secrets:
+
   ```terraform
   module "infrastructure_secrets" {
     source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/secrets?ref=stable"

--- a/README.md
+++ b/README.md
@@ -25,21 +25,27 @@ The [Example Rails deployment](EXAMPLE.md) document outlines the minimum steps r
 ## Release Process
 
 ### Git References
+
 We use three git references to manage and promote new features:
 
 #### `main` branch
+
 All new features are added here first. This branch is used in environments with the lowest risk, such as review apps, to quickly test new features, catch errors early, and minimise the impact of bugs.
 
 #### `testing` tag
+
 A pre-release is generated every week that includes any new features in `main` from the past week. This tag is automatically updated and used in low-risk environments like development or QA. This allows us to catch errors in production-like environments and keep the impact of bugs low.
 
 #### `stable` tag
+
 A release is created that includes the features which were in the `testing` phase the previous week. This tag is automatically updated and used in higher-risk environments like production or preproduction. This ensures that only thoroughly tested features are deployed.
 
 ### Promotion Process
+
 Let's assume the `stable` tag points to `v0.x.0` and `testing` points to `v0.y.0`. You can view the tags and their commit IDs [in the tags list](https://github.com/DFE-Digital/terraform-modules/tags).
 
-#### To promote `testing` to `stable`:
+#### To promote `testing` to `stable`
+
 1. Delete the current pre-release pointing to `v0.y.0`
 1. Create a new release:
     - Select `Draft new release`
@@ -49,8 +55,10 @@ Let's assume the `stable` tag points to `v0.x.0` and `testing` points to `v0.y.0
     - Check the `Set as the latest release` box
     - Click `Publish release`
 
-#### To promote new commits in `main` to `testing`:
+#### To promote new commits in `main` to `testing`
+
 If there are new commits in `main` that you want to promote to `testing`, increment `v0.y.0` to `v0.z.0`, then create a new pre-release:
+
 1. Select `Draft new release`
 1. Click `Choose a tag` and enter `v0.z.0`
 1. Click `Create new tag`
@@ -62,12 +70,14 @@ If there are new commits in `main` that you want to promote to `testing`, increm
 ## Updating [Terraform Docs]
 
 Terraform Docs can be used in two ways:
+
 ### Install
 
 - [Install Terraform Docs] according to the instructions for your platform.
 - Run `terraform-docs [module]` for each module, where `module` is the path, for example:
+
   ```sh
-  $ terraform-docs aks/application
+  terraform-docs aks/application
   ```
 
 [Terraform Docs]: https://terraform-docs.io/

--- a/aks/redis_managed/README.md
+++ b/aks/redis_managed/README.md
@@ -1,0 +1,45 @@
+# AKS Managed Redis
+
+Terraform code for deploying an Azure Managed Redis instance.
+
+## Terraform documentation
+
+For the list of requirements, inputs, outputs and resources, check the [terraform module documentation](tfdocs.md).
+
+## Usage
+
+```terraform
+module "redis_managed" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis_managed?ref=stable"
+
+  name = "cache"
+
+  namespace             = var.namespace
+  environment           = "${var.app_environment}${var.app_suffix}"
+  azure_resource_prefix = var.azure_resource_prefix
+  service_name          = "apply-for-qts"
+  service_short         = "afqts"
+  config_short          = "dv"
+
+  cluster_configuration_map = module.aks_cluster_data.configuration_map
+
+  use_azure = var.deploy_azure_backing_services
+}
+```
+
+### Monitoring
+
+If `azure_enable_monitoring` is `true`, it’s expected that the following resources already exist:
+
+- A resource group named `${azure_resource_prefix}-${service_short}-mn-rg` (where `mn` stands for monitoring and `rg` stands for resource group).
+- A monitor action group named `${azure_resource_prefix}-${service_name}` within the above resource group.
+
+## Outputs
+
+### `url`
+
+The URL of the Azure Managed Redis instance.
+
+### `connection_string`
+
+A connection string that's compatible with .NET applications to the Azure Managed Redis instance.

--- a/aks/redis_managed/data.tf
+++ b/aks/redis_managed/data.tf
@@ -1,0 +1,47 @@
+data "azurerm_resource_group" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+}
+
+data "azurerm_virtual_network" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name                = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_subnet" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name                 = "redis-snet"
+  virtual_network_name = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name  = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_resource_group" "monitoring" {
+  count = local.azure_enable_monitoring ? 1 : 0
+
+  name = "${var.azure_resource_prefix}-${var.service_short}-mn-rg"
+}
+
+data "azurerm_monitor_action_group" "main" {
+  count = local.azure_enable_monitoring ? 1 : 0
+
+  name                = "${var.azure_resource_prefix}-${var.service_name}"
+  resource_group_name = data.azurerm_resource_group.monitoring[0].name
+}
+
+data "azurerm_managed_redis" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name                = azurerm_managed_redis.main[0].name
+  resource_group_name = azurerm_managed_redis.main[0].resource_group_name
+}
+
+data "azurerm_private_dns_zone" "redis_managed" {
+  count = (var.use_azure ? 1 : 0)
+
+  name                = "redis.azure.net"
+  resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
+}

--- a/aks/redis_managed/outputs.tf
+++ b/aks/redis_managed/outputs.tf
@@ -1,0 +1,10 @@
+output "url" {
+  value     = var.use_azure ? "rediss://:${azurerm_managed_redis.main[0].default_database[0].primary_access_key}@${azurerm_managed_redis.main[0].hostname}:10000/0" : "redis://${kubernetes_service.main[0].metadata[0].name}:6379/0"
+  sensitive = true
+}
+
+
+output "connection_string" {
+  value     = var.use_azure ? "${azurerm_managed_redis.main[0].hostname}:10000,password=${azurerm_managed_redis.main[0].default_database[0].primary_access_key},ssl=true" : "${kubernetes_service.main[0].metadata[0].name}:6379"
+  sensitive = true
+}

--- a/aks/redis_managed/resources.tf
+++ b/aks/redis_managed/resources.tf
@@ -1,0 +1,211 @@
+locals {
+  name_suffix = var.name != null ? "-${var.name}" : ""
+
+  azure_name                  = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-managed-redis${local.name_suffix}"
+  azure_private_endpoint_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-managed-redis${local.name_suffix}-pe"
+  azure_enable_monitoring     = var.use_azure && var.azure_enable_monitoring
+
+  kubernetes_name = "${var.service_name}-${var.environment}-managed-redis${local.name_suffix}"
+
+  alert_frequency_map = {
+    PT5M  = "PT1M"
+    PT15M = "PT1M"
+    PT30M = "PT1M"
+    PT1H  = "PT1M"
+    PT6H  = "PT5M"
+    PT12H = "PT5M"
+  }
+  alert_frequency = local.alert_frequency_map[var.alert_window_size]
+}
+
+# Azure Managed Redis
+
+resource "azurerm_managed_redis" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name                  = local.azure_name
+  location              = data.azurerm_resource_group.main[0].location
+  resource_group_name   = data.azurerm_resource_group.main[0].name
+  sku_name              = var.azure_managed_redis_sku
+  public_network_access = var.azure_public_network_access_enabled
+
+  default_database {
+    access_keys_authentication_enabled = true
+    eviction_policy                    = var.azure_maxmemory_policy
+    clustering_policy                  = var.db_clustering_policy
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
+  timeouts {
+    create = "1h"
+    update = "1h"
+  }
+}
+
+# Required Private Endpoint
+
+resource "azurerm_private_endpoint" "main" {
+  count = var.use_azure ? 1 : 0
+
+  name                = local.azure_private_endpoint_name
+  location            = data.azurerm_resource_group.main[0].location
+  resource_group_name = data.azurerm_resource_group.main[0].name
+  subnet_id           = data.azurerm_subnet.main[0].id
+
+  private_dns_zone_group {
+    name                 = data.azurerm_private_dns_zone.redis_managed[0].name
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.redis_managed[0].id]
+  }
+
+  private_service_connection {
+    name                           = local.azure_private_endpoint_name
+    private_connection_resource_id = azurerm_managed_redis.main[0].id
+    is_manual_connection           = false
+    subresource_names              = ["redisEnterprise"]
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+# Alert if high memory usage
+
+resource "azurerm_monitor_metric_alert" "memory" {
+  count = local.azure_enable_monitoring ? 1 : 0
+
+  name                = "${azurerm_managed_redis.main[0].name}-memory"
+  resource_group_name = data.azurerm_resource_group.main[0].name
+  scopes              = [azurerm_managed_redis.main[0].id]
+  description         = "Action will be triggered when memory use is greater than ${var.azure_memory_threshold}%"
+  window_size         = var.alert_window_size
+  frequency           = local.alert_frequency
+
+  criteria {
+    metric_namespace = "Microsoft.Cache/redisEnterprise"
+    metric_name      = "usedmemorypercentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = var.azure_memory_threshold
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.main[0].id
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+
+# Kubernetes
+
+resource "kubernetes_deployment" "main" {
+  count = var.use_azure ? 0 : 1
+
+  metadata {
+    name      = local.kubernetes_name
+    namespace = var.namespace
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = local.kubernetes_name
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = local.kubernetes_name
+        }
+      }
+      spec {
+        node_selector = {
+          "teacherservices.cloud/node_pool" = "applications"
+          "kubernetes.io/os"                = "linux"
+        }
+        container {
+          name  = local.kubernetes_name
+          image = "${var.server_docker_repo}:redis-${var.server_version}-alpine"
+
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "250m"
+              memory = "1Gi"
+            }
+          }
+          port {
+            container_port = 6379
+          }
+
+          startup_probe {
+            exec {
+              command = ["redis-cli", "ping"]
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 2
+            timeout_seconds       = 3
+            success_threshold     = 1
+            failure_threshold     = 30
+          }
+
+          liveness_probe {
+            exec {
+              command = ["redis-cli", "ping"]
+            }
+            initial_delay_seconds = 30
+            period_seconds        = 10
+            timeout_seconds       = 5
+            success_threshold     = 1
+            failure_threshold     = 3
+          }
+
+          readiness_probe {
+            exec {
+              command = ["redis-cli", "ping"]
+            }
+            initial_delay_seconds = 30
+            period_seconds        = 5
+            timeout_seconds       = 3
+            success_threshold     = 1
+            failure_threshold     = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "time_sleep" "wait_redis_ready" {
+  count = var.use_azure ? 0 : 1
+
+  depends_on = [kubernetes_service.main]
+
+  create_duration = "60s"
+}
+
+resource "kubernetes_service" "main" {
+  count = var.use_azure ? 0 : 1
+
+  metadata {
+    name      = local.kubernetes_name
+    namespace = var.namespace
+  }
+  spec {
+    port {
+      port = 6379
+    }
+    selector = {
+      # Gets the exact label from kubernetes deployment resource to force an explicit dependency to create deployment before service
+      app = kubernetes_deployment.main[0].spec[0].template[0].metadata[0].labels["app"]
+    }
+  }
+}

--- a/aks/redis_managed/tfdocs.md
+++ b/aks/redis_managed/tfdocs.md
@@ -1,0 +1,63 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_managed_redis.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis) | resource |
+| [azurerm_monitor_metric_alert.memory](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_private_endpoint.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [kubernetes_deployment.main](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_service.main](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
+| [time_sleep.wait_redis_ready](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [azurerm_managed_redis.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/managed_redis) | data source |
+| [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
+| [azurerm_private_dns_zone.redis_managed](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_resource_group.monitoring](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_virtual_network.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alert_window_size"></a> [alert\_window\_size](#input\_alert\_window\_size) | The period of time that is used to monitor alert activity e,g, PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H. The interval between checks is adjusted accordingly. | `string` | `"PT5M"` | no |
+| <a name="input_azure_enable_monitoring"></a> [azure\_enable\_monitoring](#input\_azure\_enable\_monitoring) | Enable monitoring for the database server if using Azure Postgresql | `bool` | `true` | no |
+| <a name="input_azure_managed_redis_sku"></a> [azure\_managed\_redis\_sku](#input\_azure\_managed\_redis\_sku) | The features and specification of the Managed Redis instance to deploy. | `string` | `"Balanced_B1"` | no |
+| <a name="input_azure_maxmemory_policy"></a> [azure\_maxmemory\_policy](#input\_azure\_maxmemory\_policy) | Specifies how Redis decides which data to remove when it runs out of memory | `string` | `"AllKeysLRU"` | no |
+| <a name="input_azure_memory_threshold"></a> [azure\_memory\_threshold](#input\_azure\_memory\_threshold) | n/a | `number` | `80` | no |
+| <a name="input_azure_public_network_access_enabled"></a> [azure\_public\_network\_access\_enabled](#input\_azure\_public\_network\_access\_enabled) | The public network access setting for the Managed Redis instance. | `string` | `"Disabled"` | no |
+| <a name="input_azure_resource_prefix"></a> [azure\_resource\_prefix](#input\_azure\_resource\_prefix) | Prefix of Azure resources for the service | `string` | n/a | yes |
+| <a name="input_cluster_configuration_map"></a> [cluster\_configuration\_map](#input\_cluster\_configuration\_map) | Configuration map for the Kubernetes cluster | <pre>object({<br/>    resource_group_name = string,<br/>    resource_prefix     = string,<br/>    dns_zone_prefix     = optional(string),<br/>    cpu_min             = number<br/>  })</pre> | n/a | yes |
+| <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
+| <a name="input_db_clustering_policy"></a> [db\_clustering\_policy](#input\_db\_clustering\_policy) | The default database clustering policy specified at create time | `string` | `"NoCluster"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the instance that gets added as a suffix to the standard resource name. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
+| <a name="input_server_docker_repo"></a> [server\_docker\_repo](#input\_server\_docker\_repo) | n/a | `string` | `"ghcr.io/dfe-digital/teacher-services-cloud"` | no |
+| <a name="input_server_version"></a> [server\_version](#input\_server\_version) | Version of Redis server to be used in the Kubernetes container only. The version of Azure Managed Redis when deployed in Azure is managed by Redis | `string` | `"6"` | no |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
+| <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
+| <a name="input_use_azure"></a> [use\_azure](#input\_use\_azure) | Whether to deploy using Azure Managed Redis service or Kubernetes. true = Azure Service, false = Kubernetes | `bool` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_connection_string"></a> [connection\_string](#output\_connection\_string) | n/a |
+| <a name="output_url"></a> [url](#output\_url) | n/a |

--- a/aks/redis_managed/variables.tf
+++ b/aks/redis_managed/variables.tf
@@ -1,0 +1,134 @@
+variable "use_azure" {
+  type        = bool
+  description = "Whether to deploy using Azure Managed Redis service or Kubernetes. true = Azure Service, false = Kubernetes"
+}
+
+variable "name" {
+  type        = string
+  description = "Name of the instance that gets added as a suffix to the standard resource name."
+  default     = null
+}
+
+variable "namespace" {
+  type        = string
+  description = "Current namespace"
+}
+
+variable "environment" {
+  type        = string
+  description = "Current application environment"
+}
+
+variable "azure_resource_prefix" {
+  type        = string
+  description = "Prefix of Azure resources for the service"
+}
+
+variable "service_name" {
+  type        = string
+  description = "Name of the service"
+}
+
+variable "service_short" {
+  type        = string
+  description = "Short name of the service"
+}
+
+variable "config_short" {
+  type        = string
+  description = "Short name of the configuration"
+}
+
+variable "cluster_configuration_map" {
+  type = object({
+    resource_group_name = string,
+    resource_prefix     = string,
+    dns_zone_prefix     = optional(string),
+    cpu_min             = number
+  })
+  description = "Configuration map for the Kubernetes cluster"
+}
+
+variable "server_version" {
+  type        = string
+  nullable    = false
+  default     = "6"
+  description = "Version of Redis server to be used in the Kubernetes container only. The version of Azure Managed Redis when deployed in Azure is managed by Redis"
+}
+
+variable "azure_public_network_access_enabled" {
+  description = "The public network access setting for the Managed Redis instance."
+  type        = string
+  nullable    = true
+  default     = "Disabled"
+}
+
+variable "azure_memory_threshold" {
+  type    = number
+  default = 80
+}
+
+variable "azure_maxmemory_policy" {
+  description = "Specifies how Redis decides which data to remove when it runs out of memory"
+  type        = string
+  default     = "AllKeysLRU"
+  nullable    = false
+  validation {
+    condition = contains(["AllKeysLFU", "AllKeysLRU", "AllKeysRandom", "VolatileLRU", "VolatileLFU", "VolatileTTL",
+    "VolatileRandom", "NoEviction"], var.azure_maxmemory_policy)
+    error_message = "The azure_maxmemory_policy must be one of AllKeysLFU, AllKeysLRU, AllKeysRandom, VolatileLRU, VolatileLFU, VolatileTTL"
+  }
+}
+
+variable "db_clustering_policy" {
+  description = "The default database clustering policy specified at create time"
+  type        = string
+  default     = "NoCluster"
+  validation {
+    condition     = contains(["EnterpriseCluster", "OSSCluster", "NoCluster"], var.db_clustering_policy)
+    error_message = "The db_clustering_policy must be one of EnterpriseCluster, OSSCluster, NoCluster"
+  }
+}
+
+variable "azure_enable_monitoring" {
+  description = "Enable monitoring for the database server if using Azure Postgresql"
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "alert_window_size" {
+  type     = string
+  default  = "PT5M"
+  nullable = false
+  validation {
+    condition     = contains(["PT1M", "PT5M", "PT15M", "PT30M", "PT1H", "PT6H", "PT12H"], var.alert_window_size)
+    error_message = "The alert_window_size must be one of: PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H"
+  }
+  description = "The period of time that is used to monitor alert activity e,g, PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H. The interval between checks is adjusted accordingly."
+}
+
+variable "server_docker_repo" {
+  type     = string
+  nullable = false
+  default  = "ghcr.io/dfe-digital/teacher-services-cloud"
+}
+
+variable "azure_managed_redis_sku" {
+  description = "The features and specification of the Managed Redis instance to deploy."
+  type        = string
+  default     = "Balanced_B1"
+  nullable    = false
+  validation {
+    condition = contains(["Balanced_B0", "Balanced_B1", "Balanced_B10", "Balanced_B100", "Balanced_B1000", "Balanced_B150",
+      "Balanced_B20", "Balanced_B250", "Balanced_B3", "Balanced_B350", "Balanced_B5", "Balanced_B50", "Balanced_B500", "Balanced_B700",
+      "ComputeOptimized_X10", "ComputeOptimized_X100", "ComputeOptimized_X150", "ComputeOptimized_X20", "ComputeOptimized_X250",
+      "ComputeOptimized_X3", "ComputeOptimized_X350", "ComputeOptimized_X5", "ComputeOptimized_X50", "ComputeOptimized_X500",
+      "ComputeOptimized_X700", "FlashOptimized_A1000", "FlashOptimized_A1500", "FlashOptimized_A2000", "FlashOptimized_A250",
+      "FlashOptimized_A4500", "FlashOptimized_A500", "FlashOptimized_A700", "MemoryOptimized_M10", "MemoryOptimized_M100",
+      "MemoryOptimized_M1000", "MemoryOptimized_M150", "MemoryOptimized_M1500", "MemoryOptimized_M20", "MemoryOptimized_M2000",
+      "MemoryOptimized_M250", "MemoryOptimized_M350", "MemoryOptimized_M50", "MemoryOptimized_M500", "MemoryOptimized_M700"],
+    var.azure_managed_redis_sku)
+    error_message = "The SKU must be one the values defined at https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis#sku_name-1"
+  }
+}

--- a/aks/storage_account/README.md
+++ b/aks/storage_account/README.md
@@ -259,7 +259,7 @@ This module implements the following security features by default:
 ## Environment-based Configuration
 
 | Environment                               | Replication Type  | Override Available? |
-| ----------------------------------------- | ----------------- | ------------------- |
+|-------------------------------------------|-------------------|---------------------|
 | Non-Production (dev, test, staging, etc.) | **LRS** (forced)  | ❌ No               |
 | Production                                | **GRS** (default) | ✅ Yes (GRS or ZRS) |
 


### PR DESCRIPTION
## Context
New **redis_managed** module for the migration from Azure Cache for Redis to Azure Managed Redis.

## Changes proposed in this pull request
A new module based on the **redis** module with basic configuration changes allowed.

## Guidance to review
I tested a deployment using apply-for-teacher-training dv_review.

The Terraform provider plugins version had to be updated to 4.71.0.

I added 2 module sections and one new variable for the SKU type as it differs from the Cache for Redis SKU type.

I deployed the module with 2 Managed Redis instances simultaneously with 2 Cache for Redis instances. Once all 4 were running, I changed 2 application variables to point at the new Managed Redis instances.

Without the Redis instances or using malformed URLs, the response times from the review app webpage was very slow for a page refresh. When switched to correct Managed Redis URLs the page response times were immediate.

Looking at the Monitoring with dashboard for Grafana didn't really help convince me tat all was working as it should so I'm relying on the response time as my only indicator of success.

I also  tested a rollback to point to the original Cache for Redis instances.

Finally I terminated the old Cache for Redis instances.

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
