### PR TITLE
Increase immutable backup policy from 6 to 14 days

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -184,7 +184,7 @@ resource "azurerm_storage_container_immutability_policy" "backup" {
   count = local.azure_enable_backup_storage && var.environment == "production" ? 1 : 0
 
   storage_container_resource_manager_id = "${azurerm_storage_container.backup[0].storage_account_id}/blobServices/default/containers/database-backup"
-  immutability_period_in_days           = 6
+  immutability_period_in_days           = 14
   protected_append_writes_all_enabled   = false
   protected_append_writes_enabled       = false
 


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Production postgres backups are currently kept for 1 week (6 days) 
via an immutability policy on the Azure Blob Storage container. 
This should be increased to 2 weeks for better disaster recovery coverage.

## Changes proposed in this pull request
Increased immutability_period_in_days from 6 to 14 in 
aks/postgres/resources.tf. This applies to all production 
environments using the postgres module with backup storage enabled.

## Guidance to review
Single line change in the immutability policy resource block in 
aks/postgres/resources.tf. Only affects production environments 
as the resource is gated by var.environment == "production". 
No other infrastructure changes included.

## Before merging
<!-- Any extra steps like: delete temp commit, send warning, wait after office hours... -->

## After merging
<!-- Any extra steps like: update other PR, apply manually, inform someone... -->

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
