### PR TITLE
Add storage account queue support

### DIFF
--- a/aks/storage_account/data.tf
+++ b/aks/storage_account/data.tf
@@ -1,4 +1,3 @@
-
 data "azurerm_resource_group" "main" {
   name = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
 }
@@ -19,5 +18,11 @@ data "azurerm_subnet" "priv" {
 data "azurerm_private_dns_zone" "priv" {
   count               = var.use_private_storage ? 1 : 0
   name                = "privatelink.blob.core.windows.net"
+  resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
+}
+
+data "azurerm_private_dns_zone" "priv_queue" {
+  count               = var.use_private_storage && length(var.queues) > 0 ? 1 : 0
+  name                = "privatelink.queue.core.windows.net"
   resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
 }

--- a/aks/storage_account/outputs.tf
+++ b/aks/storage_account/outputs.tf
@@ -25,6 +25,11 @@ output "primary_blob_endpoint" {
   value       = azurerm_storage_account.main.primary_blob_endpoint
 }
 
+output "primary_queue_endpoint" {
+  description = "The primary queue endpoint URL"
+  value       = azurerm_storage_account.main.primary_queue_endpoint
+}
+
 output "containers" {
   description = "A map of container names to their properties"
   value = {
@@ -36,4 +41,17 @@ output "containers" {
 
 output "storage_private_blob_fqdn" {
   value = var.use_private_storage ? "${azurerm_storage_account.main.name}.privatelink.blob.core.windows.net" : null
+}
+
+output "storage_private_queue_fqdn" {
+  value = var.use_private_storage && length(var.queues) > 0 ? "${azurerm_storage_account.main.name}.privatelink.queue.core.windows.net" : null
+}
+
+output "queues" {
+  description = "A map of queue names to their properties"
+  value = {
+    for name, queue in azurerm_storage_queue.queues : name => {
+      id = queue.id
+    }
+  }
 }

--- a/aks/storage_account/resources.tf
+++ b/aks/storage_account/resources.tf
@@ -58,6 +58,11 @@ resource "azurerm_storage_container" "containers" {
   name               = each.value.name
   storage_account_id = azurerm_storage_account.main.id
 }
+resource "azurerm_storage_queue" "queues" {
+  for_each           = { for queue in var.queues : queue.name => queue }
+  name               = each.value.name
+  storage_account_id = azurerm_storage_account.main.id
+}
 
 resource "azurerm_storage_management_policy" "main" {
   count = var.blob_delete_after_days > 0 ? 1 : 0
@@ -105,4 +110,29 @@ resource "azurerm_private_endpoint" "storage" {
     ]
   }
 
+}
+
+resource "azurerm_private_endpoint" "storage_queue" {
+  count = var.use_private_storage && length(var.queues) > 0 ? 1 : 0
+
+  name                = "${local.storage_account_name}-queue-pe"
+  location            = data.azurerm_resource_group.main.location
+  resource_group_name = data.azurerm_resource_group.main.name
+  subnet_id           = data.azurerm_subnet.priv[0].id
+
+  private_dns_zone_group {
+    name                 = data.azurerm_private_dns_zone.priv_queue[0].name
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.priv_queue[0].id]
+  }
+
+  private_service_connection {
+    name                           = "${local.storage_account_name}-queue-pe"
+    private_connection_resource_id = azurerm_storage_account.main.id
+    subresource_names              = ["queue"]
+    is_manual_connection           = false
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }

--- a/aks/storage_account/tfdocs.md
+++ b/aks/storage_account/tfdocs.md
@@ -17,11 +17,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_private_endpoint.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_storage_account.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.containers](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_encryption_scope.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_encryption_scope) | resource |
 | [azurerm_storage_management_policy.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
+| [azurerm_storage_queue.queues](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_private_dns_zone.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.priv_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
 | [azurerm_virtual_network.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
@@ -46,6 +49,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the storage account (without prefix and suffix) | `string` | `null` | no |
 | <a name="input_production_replication_type"></a> [production\_replication\_type](#input\_production\_replication\_type) | Replication type for production environments. Non-production environments always use LRS for cost efficiency. | `string` | `"GRS"` | no |
 | <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled) | Whether public network access is allowed for the storage account | `bool` | `false` | no |
+| <a name="input_queues"></a> [queues](#input\_queues) | List of queues to create on the storage account. Requires use\_private\_storage = true for private network access. | `list(object({ name = string }))` | `[]` | no |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
 | <a name="input_storage_account_name_override"></a> [storage\_account\_name\_override](#input\_storage\_account\_name\_override) | Override the generated storage account name with a custom name | `string` | `null` | no |
 | <a name="input_use_private_storage"></a> [use\_private\_storage](#input\_use\_private\_storage) | Whether to deploy a private Storage Account | `bool` | `false` | no |
@@ -60,4 +64,7 @@ No modules.
 | <a name="output_primary_access_key"></a> [primary\_access\_key](#output\_primary\_access\_key) | The primary access key for the Storage Account |
 | <a name="output_primary_blob_endpoint"></a> [primary\_blob\_endpoint](#output\_primary\_blob\_endpoint) | The primary blob endpoint URL |
 | <a name="output_primary_connection_string"></a> [primary\_connection\_string](#output\_primary\_connection\_string) | The primary connection string for the Storage Account |
+| <a name="output_primary_queue_endpoint"></a> [primary\_queue\_endpoint](#output\_primary\_queue\_endpoint) | The primary queue endpoint URL |
+| <a name="output_queues"></a> [queues](#output\_queues) | A map of queue names to their properties |
 | <a name="output_storage_private_blob_fqdn"></a> [storage\_private\_blob\_fqdn](#output\_storage\_private\_blob\_fqdn) | n/a |
+| <a name="output_storage_private_queue_fqdn"></a> [storage\_private\_queue\_fqdn](#output\_storage\_private\_queue\_fqdn) | n/a |

--- a/aks/storage_account/variables.tf
+++ b/aks/storage_account/variables.tf
@@ -132,3 +132,9 @@ variable "use_private_storage" {
   description = "Whether to deploy a private Storage Account"
   default     = false
 }
+
+variable "queues" {
+  type        = list(object({ name = string }))
+  description = "List of queues to create on the storage account. Requires use_private_storage = true for private network access."
+  default     = []
+}


### PR DESCRIPTION
## Context
CYPD want to use Storage Account queues but the module only supported blob storage. This adds queue support with its own private endpoint, DNS zone wiring and outputs so consuming services can start using queues privately.

## Changes proposed in this pull request
Four files touched in aks/storage_account:

- variables.tf: new queues variable, defaults to empty so existing deployments are unaffected
- data.tf: data source for the privatelink.queue.core.windows.net DNS zone, gated on use_private_storage
- resources.tf: azurerm_storage_queue resource and a second private endpoint for the queue sub-resource, follows the same pattern as the existing blob endpoint
- outputs.tf: storage_private_queue_fqdn and queues outputs

## Guidance to review

- Everything mirrors the existing blob private endpoint pattern. Worth checking:
- DNS zone data source points to the queue zone
- Private endpoint uses subresource queue not blob
- storage_account_id used (not the deprecated storage_account_name)

## Before merging

- Confirm the teacher-services-cloud DNS zone PR is merged and applied.

## After merging


## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
