### PR TITLE
Correct private zone lookup for Azure Redis Module

### DIFF
--- a/aks/redis_managed/data.tf
+++ b/aks/redis_managed/data.tf
@@ -42,6 +42,6 @@ data "azurerm_managed_redis" "main" {
 data "azurerm_private_dns_zone" "redis_managed" {
   count = (var.use_azure ? 1 : 0)
 
-  name                = "redis.azure.net"
+  name                = "privatelink.redis.cache.windows.net"
   resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
 }


### PR DESCRIPTION
## Context
Private zone lookup for new Azure Redis module fails using wrong zone name

## Changes proposed in this pull request
Correct name used for zone lookup for Azure Redis.

## Guidance to review
for any service test using Azure Redis and private endpoint, example:
```
git clone git@github.com:DFE-Digital/education-provider-registry-web.git
cd education-provider-registry-web
git checkout sample-redis-issue
make development terraform-plan
```

This will fail with:
```
 Error: Private Dns Zone (Subscription: "20da9d12-7ee1-42bb-b969-3fe9112964a7"
│ Resource Group Name: "s189t01-tsc-test-bs-rg"
│ Private Dns Zone Name: "redis.azure.net") was not found
│ 
│   with module.redis_managed.data.azurerm_private_dns_zone.redis_managed[0],
│   on vendor/modules/aks/aks/redis_managed/data.tf line 42, in data "azurerm_private_dns_zone" "redis_managed":
│   42: data "azurerm_private_dns_zone" "redis_managed" {
```

Alter to use this branch, update `global_config\development.sh` set `TERRAFORM_MODULES_TAG=fix-azure-redis-privatelink`

re-run:
`make development terraform-plan`

This should now work.