### PR TITLE
sets invalid_cdc_cursor_position_behavior to re-sync data for airbyte

### DIFF
--- a/aks/airbyte/resources.tf
+++ b/aks/airbyte/resources.tf
@@ -25,11 +25,12 @@ resource "airbyte_source_postgres" "source_postgres" {
     }
     replication_method = {
       read_changes_using_write_ahead_log_cdc = {
-        replication_slot       = "airbyte_slot"
-        publication            = "airbyte_publication"
-        plugin                 = "pgoutput"
-        initial_snapshot       = true
-        heartbeat_action_query = "UPDATE airbyte_heartbeat SET last_heartbeat = now() WHERE id = 1;"
+        replication_slot                     = "airbyte_slot"
+        publication                          = "airbyte_publication"
+        plugin                               = "pgoutput"
+        initial_snapshot                     = true
+        heartbeat_action_query               = "UPDATE airbyte_heartbeat SET last_heartbeat = now() WHERE id = 1;"
+        invalid_cdc_cursor_position_behavior = "Re-sync data"
       }
     }
   }


### PR DESCRIPTION
<!-- Delete sections if not required -->

## Context
Sets the invalid_cdc_cursor_position_behavior to Re-sync data for the resource "airbyte_source_postgres" "source_postgres"

## Changes proposed in this pull request
Sets the replication option invalid_cdc_cursor_position_behavior to Re-sync data changing it from the default option of Fail sync

## Guidance to review
Can be tested by pointing the qa env for register-trainee-teachers to this branch and running a terraform-plan against qa. observe ~ invalid_cdc_cursor_position_behavior = "Fail sync" -> "Re-sync data" as proposed change in the plan

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
