### PR TITLE
Add variable for Azure Managed Redis High availability and default to off

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Shared modules used by various DfE services.
 - [aks/job_configuration](aks/job_configuration)
 - [aks/postgres](aks/postgres)
 - [aks/redis](aks/redis)
+- [aks/redis_managed](aks/redis_managed)
 - [aks/secrets](aks/secrets)
 - [dns/records](dns/records)
 - [dns/zones](dns/zones)

--- a/aks/redis_managed/resources.tf
+++ b/aks/redis_managed/resources.tf
@@ -23,11 +23,12 @@ locals {
 resource "azurerm_managed_redis" "main" {
   count = var.use_azure ? 1 : 0
 
-  name                  = local.azure_name
-  location              = data.azurerm_resource_group.main[0].location
-  resource_group_name   = data.azurerm_resource_group.main[0].name
-  sku_name              = var.azure_managed_redis_sku
-  public_network_access = var.azure_public_network_access_enabled
+  name                      = local.azure_name
+  location                  = data.azurerm_resource_group.main[0].location
+  resource_group_name       = data.azurerm_resource_group.main[0].name
+  sku_name                  = var.azure_managed_redis_sku
+  high_availability_enabled = var.managed_redis_high_availability
+  public_network_access     = var.azure_public_network_access_enabled
 
   default_database {
     access_keys_authentication_enabled = true

--- a/aks/redis_managed/tfdocs.md
+++ b/aks/redis_managed/tfdocs.md
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
 | <a name="input_db_clustering_policy"></a> [db\_clustering\_policy](#input\_db\_clustering\_policy) | The default database clustering policy specified at create time | `string` | `"NoCluster"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
+| <a name="input_managed_redis_high_availability"></a> [managed\_redis\_high\_availability](#input\_managed\_redis\_high\_availability) | Whether to enable high availability for the Managed Redis instance. Defaults to false. Changing this forces a new Managed Redis instance to be created. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance that gets added as a suffix to the standard resource name. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
 | <a name="input_server_docker_repo"></a> [server\_docker\_repo](#input\_server\_docker\_repo) | n/a | `string` | `"ghcr.io/dfe-digital/teacher-services-cloud"` | no |

--- a/aks/redis_managed/variables.tf
+++ b/aks/redis_managed/variables.tf
@@ -132,3 +132,9 @@ variable "azure_managed_redis_sku" {
     error_message = "The SKU must be one the values defined at https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis#sku_name-1"
   }
 }
+
+variable "managed_redis_high_availability" {
+  type        = bool
+  description = "Whether to enable high availability for the Managed Redis instance. Defaults to false. Changing this forces a new Managed Redis instance to be created."
+  default     = false
+}


### PR DESCRIPTION
## Context
Cost savings, turn off high availability for Managed Redis by default.

## Changes proposed in this pull request
add optional variable to enable high availability with a default of false (off) for Azure Managed Redis
Add managed Redis link to main Readme

## Guidance to review
Clone a service repo and test plan, update global_config\<env>.sh to use `TERRAFORM_MODULES_TAG=redis-docs-update`
make <env> terraform-plan

Check for       `+ high_availability_enabled = false`
```
 # module.redis_managed.azurerm_managed_redis.main[0] will be created
  + resource "azurerm_managed_redis" "main" {
      + high_availability_enabled = false
      + hostname                  = (known after apply)
      + id                        = (known after apply)
      + location                  = "uksouth"
      + name                      = "s189t01-eprweb-development-managed-redis"
      + public_network_access     = "Disabled"
      + resource_group_name       = "s189t01-eprweb-dv-rg"
      + sku_name                  = "Balanced_B1"

      + default_database {
          + access_keys_authentication_enabled = true
          + client_protocol                    = "Encrypted"
          + clustering_policy                  = "NoCluster"
          + eviction_policy                    = "AllKeysLRU"
          + id                                 = (known after apply)
          + port                               = (known after apply)
          + primary_access_key                 = (sensitive value)
          + secondary_access_key               = (sensitive value)
        }

      + timeouts {
          + create = "1h"
          + update = "1h"
        }
    }
```
