### PR TITLE
2848 - Additional postgres config for HA Airbyte

### DIFF
--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -441,3 +441,19 @@ resource "azurerm_postgresql_flexible_server_configuration" "min_wal_size" {
   server_id = azurerm_postgresql_flexible_server.main[0].id
   value     = 2048
 }
+
+resource "azurerm_postgresql_flexible_server_configuration" "sync_replication_slots" {
+  count = var.use_azure && var.use_airbyte && var.azure_enable_high_availability && var.server_version >= 17 ? 1 : 0
+  # Parameter min_wal_size = 2048 MB the lower limit that ensures enough WAL files are retained or reused to prevent the disk space from shrinking too much between checkpoints
+  name      = "sync_replication_slots"
+  server_id = azurerm_postgresql_flexible_server.main[0].id
+  value     = var.sync_replication_slots
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "hot_standby_feedback" {
+  count = var.use_azure && var.use_airbyte && var.azure_enable_high_availability && var.server_version >= 17 ? 1 : 0
+  # Parameter min_wal_size = 2048 MB the lower limit that ensures enough WAL files are retained or reused to prevent the disk space from shrinking too much between checkpoints
+  name      = "hot_standby_feedback"
+  server_id = azurerm_postgresql_flexible_server.main[0].id
+  value     = var.hot_standby_feedback
+}

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -26,11 +26,13 @@ No modules.
 | [azurerm_postgresql_flexible_server.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server) | resource |
 | [azurerm_postgresql_flexible_server_configuration.azure_extensions](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.connection_throttling](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
+| [azurerm_postgresql_flexible_server_configuration.hot_standby_feedback](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_connections](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_replication_slots](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_wal_senders](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.max_wal_size](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.min_wal_size](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
+| [azurerm_postgresql_flexible_server_configuration.sync_replication_slots](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.wal_level](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
 | [azurerm_storage_account.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
@@ -72,6 +74,7 @@ No modules.
 | <a name="input_config_short"></a> [config\_short](#input\_config\_short) | Short name of the configuration | `string` | n/a | yes |
 | <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Create default database. If the app creates the database instead of this module, set to false. Default: true | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Current application environment | `string` | n/a | yes |
+| <a name="input_hot_standby_feedback"></a> [hot\_standby\_feedback](#input\_hot\_standby\_feedback) | A Postgres config setting required for version 17 and above on HA for slot replication. Important for AirByte | `string` | `"on"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the instance | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Current namespace | `string` | n/a | yes |
 | <a name="input_server_docker_image"></a> [server\_docker\_image](#input\_server\_docker\_image) | Docker Hub image for the kubernetes deployment, eg. postgis/postgis:16-3.5. Default is postgres:<server\_version>-alpine | `string` | `null` | no |
@@ -79,6 +82,7 @@ No modules.
 | <a name="input_server_version"></a> [server\_version](#input\_server\_version) | Version of PostgreSQL server | `string` | `"16"` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
+| <a name="input_sync_replication_slots"></a> [sync\_replication\_slots](#input\_sync\_replication\_slots) | A Postgres config setting required for version 17 and above on HA for slot replication. Important for AirByte | `string` | `"on"` | no |
 | <a name="input_use_airbyte"></a> [use\_airbyte](#input\_use\_airbyte) | Whether to add configuration changes required by Airbyte | `bool` | `false` | no |
 | <a name="input_use_azure"></a> [use\_azure](#input\_use\_azure) | Whether to deploy using Azure Redis Cache service | `bool` | n/a | yes |
 

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -179,6 +179,26 @@ variable "use_airbyte" {
   description = "Whether to add configuration changes required by Airbyte"
 }
 
+variable "sync_replication_slots" {
+  description = "A Postgres config setting required for version 17 and above on HA for slot replication. Important for AirByte"
+  type        = string
+  default     = "on"
+  validation {
+    condition     = contains(["on", "off"], var.sync_replication_slots)
+    error_message = "The sync_replication_slots must be one of: on, off"
+  }
+}
+
+variable "hot_standby_feedback" {
+  description = "A Postgres config setting required for version 17 and above on HA for slot replication. Important for AirByte"
+  type        = string
+  default     = "on"
+  validation {
+    condition     = contains(["on", "off"], var.hot_standby_feedback)
+    error_message = "The hot_standby_feedback must be one of: on, off"
+  }
+}
+
 locals {
   server_docker_image = var.server_docker_image == null ? "${var.server_docker_repo}:postgres-${var.server_version}-alpine" : var.server_docker_image
   command             = var.use_airbyte ? ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=2", "-c", "max_replication_slots=1", "-c", "max_slot_wal_keep_size=2048"] : null


### PR DESCRIPTION
## Context
For services using AirByte and logical replication, we are losing the replication slot on major upgrades. On moving to Postgres 17 we need 2 additional configuration settings for it to work.

## Changes proposed in this pull request
Create 2 new azurerm_postgresql_flexible_server_configuration resource blocks in terraform-modules->aks->postgres which are implemented if use_azure, use_airbyte and azure_enable_high_availability are all set to true and the version of Postgres is 17 or greater.
These need to set sync_replication_slots and hot_standby_feedback to "on".

## Guidance to review
- Select a service that's using Postgres and AirByte (**rtt**, trs or ptt). Create a branch in that service. Use dv_review (dv_review.tfvars.json).
  - Set TERRAFORM_MODULES_TAG = to this branch. 
  - Set "deploy_azure_backing_services": true
  - Set "pg_airbyte_enabled": true
  - Set "postgres_enable_high_availability": true
  - Set ""postgres_flexible_server_sku": "GP_Standard_D4ds_v5"
  - Add `"PLPGSQL"` to the azure_extensions list in the postgres module in database.tf
  - Set "postgres_version": "16"
  - Run a plan `make dv_review terraform-plan CLUSTER=cluster2 APP_NAME=2848`. You should not see sync_replication_slots or hot_standby_feedback being created
  - You can also check the other flag by setting pg_airbyte_enabled to false. There's no real point to checking deploy_azure_backing_services as false.
  - Set "postgres_server_version": "17"
  - Set sync_replication_slots and hot_standby_feedback to "off" by adding the following to databases.tf -> module "postgres"
      ```hcl
         hot_standby_feedback   = var.pg_hot_standby_feedback
         sync_replication_slots = var.pg_sync_replication_slots
      ```
  - and add the following to variables.tf
      ```hcl
         variable "pg_sync_replication_slots" {
             description = "Whether to enable synchronous replication slots for Postgres. Valid values are 'on' or 'off'."
             type = string
             default = "on"
         }

         variable "pg_hot_standby_feedback" {
             description = "Whether to enable hot standby feedback for Postgres. Valid values are 'on' or 'off'."
             type = string
             default = "on"
         }
      ```
  - Add to dv_review.tfvars.json
     ```hcl
        "pg_sync_replication_slots" : "off",
        "pg_hot_standby_feedback": "off",
     ```
  - Run a plan `make dv_review terraform-plan CLUSTER=cluster2 APP_NAME=2848`. You should not see sync_replication_slots or hot_standby_feedback being created
  - Run apply `make dv_review terraform-apply CLUSTER=cluster2 APP_NAME=2848`
  - Remove the sync_replication_slots and hot_standby_feedback settings from dv_review.tfvars.json
  - Run apply `make dv_review terraform-apply CLUSTER=cluster2 APP_NAME=2848` You should see the 2 config settings. Saying yes to the apply should not **restart** or **degrade** the Postgres database.

## Before merging
These two settings should be safe to deploy without impact to the live environment. They do not require a restart of the server.

## After merging
Have the affected services monitor their applications.
To rollback
- Set sync_replication_slots to "off"
- Set hot_standby_feedback to "off"

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
