### PR TITLE
Add airbyte_sync_mode variable to Airbyte module

### DIFF
--- a/aks/airbyte/resources.tf
+++ b/aks/airbyte/resources.tf
@@ -121,7 +121,9 @@ module "dotnet_streams_update_job" {
     "--airbyte-client-secret",
     var.client_secret,
     "--airbyte-connection-id",
-    airbyte_connection.connection.connection_id
+    airbyte_connection.connection.connection_id,
+    "--airbyte-sync-mode",
+    var.airbyte_sync_mode
   ]
   job_name       = "airbyte-stream-update"
   enable_logit   = true

--- a/aks/airbyte/tfdocs.md
+++ b/aks/airbyte/tfdocs.md
@@ -55,6 +55,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_airbyte_sync_mode"></a> [airbyte\_sync\_mode](#input\_airbyte\_sync\_mode) | The Airbyte sync mode | `string` | `"incremental_append"` | no |
 | <a name="input_azure_resource_prefix"></a> [azure\_resource\_prefix](#input\_azure\_resource\_prefix) | Prefix of Azure resources for the service | `string` | n/a | yes |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | Airbyte client id | `string` | n/a | yes |
 | <a name="input_client_secret"></a> [client\_secret](#input\_client\_secret) | Airbyte client secret | `string` | n/a | yes |

--- a/aks/airbyte/variables.tf
+++ b/aks/airbyte/variables.tf
@@ -140,6 +140,17 @@ variable "dotnet_application_directory" {
   description = "The path to application containing the dfe-analytics directory"
 }
 
+variable "airbyte_sync_mode" {
+  type        = string
+  default     = "incremental_append"
+  description = "The Airbyte sync mode"
+
+  validation {
+    condition     = contains(["incremental_append", "incremental_deduped_history"], var.airbyte_sync_mode)
+    error_message = "Sync mode must be incremental_append, or incremental_deduped_history."
+  }
+}
+
 locals {
   source_name      = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-pg-source"
   destination_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-bq-destination"


### PR DESCRIPTION
## Context
We want to set the Airbyte sync mode via a variable on the Airbyte module, rather than in application code.

## Changes proposed in this pull request
Adds an optional `airbyte_sync_mode` variable to the airbyte module, defaulted to `incremental_append`.
Updates the deployment job for .NET apps to set the `--airbyte-sync-mode` option.

## Guidance to review
Tested in a branch with TRS (see https://github.com/DFE-Digital/teaching-record-system/compare/main...analytics-syncmode-config#diff-4adcfcbd0840f461a231119a22ef986fc1c9a375ec0a925ab83106790aa3f3e1R43)

## Before merging
None

## After merging
None

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
~~- [ ] I have attached the pull request to the trello card~~
