### PR TITLE
Add additional GCP policy tags option to Airbyte module

### DIFF
--- a/aks/airbyte/resources.tf
+++ b/aks/airbyte/resources.tf
@@ -101,7 +101,7 @@ module "dotnet_streams_update_job" {
   service_name = var.service_name
   docker_image = var.docker_image
   commands     = ["/bin/sh"]
-  arguments = [
+  arguments = flatten([
     "-f",
     "${coalesce(trimsuffix(var.dotnet_application_directory, "/"), ".")}/dfe-analytics/apply-config.sh",
     "--connection-string",
@@ -114,6 +114,7 @@ module "dotnet_streams_update_job" {
     local.gcp_dataset_name,
     "--hidden-policy-tag-name",
     local.gcp_policy_tag_name,
+    [for alias, tag in var.additional_policy_tags : ["--policy-tag", alias, "projects/${data.google_project.main.project_id}/locations/${local.gcp_region}/taxonomies/${var.gcp_taxonomy_id}/policyTags/${tag}"]],
     "--airbyte-api-base-address",
     var.server_url,
     "--airbyte-client-id",
@@ -124,7 +125,7 @@ module "dotnet_streams_update_job" {
     airbyte_connection.connection.connection_id,
     "--airbyte-sync-mode",
     var.airbyte_sync_mode
-  ]
+  ])
   job_name       = "airbyte-stream-update"
   enable_logit   = true
   enable_gcp_wif = true

--- a/aks/airbyte/tfdocs.md
+++ b/aks/airbyte/tfdocs.md
@@ -55,6 +55,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_policy_tags"></a> [additional\_policy\_tags](#input\_additional\_policy\_tags) | A map of policy tag aliases to tag IDs | `map(string)` | `{}` | no |
 | <a name="input_airbyte_sync_mode"></a> [airbyte\_sync\_mode](#input\_airbyte\_sync\_mode) | The Airbyte sync mode | `string` | `"incremental_append"` | no |
 | <a name="input_azure_resource_prefix"></a> [azure\_resource\_prefix](#input\_azure\_resource\_prefix) | Prefix of Azure resources for the service | `string` | n/a | yes |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | Airbyte client id | `string` | n/a | yes |

--- a/aks/airbyte/variables.tf
+++ b/aks/airbyte/variables.tf
@@ -151,6 +151,12 @@ variable "airbyte_sync_mode" {
   }
 }
 
+variable "additional_policy_tags" {
+  type        = map(string)
+  default     = {}
+  description = "A map of policy tag aliases to tag IDs"
+}
+
 locals {
   source_name      = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-pg-source"
   destination_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-bq-destination"


### PR DESCRIPTION
## Context
Some services, like TRS, need to have multiple policy tags applied to their BQ datasets. Currently we only support a single one - the hidden policy tag.

## Changes proposed in this pull request
Adds a new, optional map variable to the airbyte module - `additional_policy_tags` - where a caller can add mappings from a policy alias to the tag ID. These then get expanded into the full GCP policy name and passed along to the deployment job.

## Guidance to review
Tested on a branch with TRS - https://github.com/DFE-Digital/teaching-record-system/commit/cfbced6202fcf1bd5535036485515fa527951268

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
~~- [ ] I have attached the pull request to the trello card~~
