### PR TITLE
Add option to skip policy tag application

### DIFF
--- a/aks/airbyte/resources.tf
+++ b/aks/airbyte/resources.tf
@@ -115,6 +115,8 @@ module "dotnet_streams_update_job" {
     "--hidden-policy-tag-name",
     local.gcp_policy_tag_name,
     [for alias, tag in var.additional_policy_tags : ["--policy-tag", alias, "projects/${data.google_project.main.project_id}/locations/${local.gcp_region}/taxonomies/${var.gcp_taxonomy_id}/policyTags/${tag}"]],
+    "--skip-policy-tags",
+    var.skip_policy_tags,
     "--airbyte-api-base-address",
     var.server_url,
     "--airbyte-client-id",

--- a/aks/airbyte/tfdocs.md
+++ b/aks/airbyte/tfdocs.md
@@ -89,6 +89,7 @@
 | <a name="input_server_url"></a> [server\_url](#input\_server\_url) | Server url | `string` | `null` | no |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the service | `string` | n/a | yes |
 | <a name="input_service_short"></a> [service\_short](#input\_service\_short) | Short name of the service | `string` | n/a | yes |
+| <a name="input_skip_policy_tags"></a> [skip\_policy\_tags](#input\_skip\_policy\_tags) | Whether to skip applying policy tags to tables in Big Query | `bool` | `false` | no |
 | <a name="input_use_azure"></a> [use\_azure](#input\_use\_azure) | Whether to deploy using Azure Postgres | `bool` | n/a | yes |
 | <a name="input_workspace_id"></a> [workspace\_id](#input\_workspace\_id) | Airbyte workspace id | `string` | `null` | no |
 

--- a/aks/airbyte/variables.tf
+++ b/aks/airbyte/variables.tf
@@ -157,6 +157,12 @@ variable "additional_policy_tags" {
   description = "A map of policy tag aliases to tag IDs"
 }
 
+variable "skip_policy_tags" {
+  type        = bool
+  default     = false
+  description = "Whether to skip applying policy tags to tables in Big Query"
+}
+
 locals {
   source_name      = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-pg-source"
   destination_name = "${var.azure_resource_prefix}-${var.service_short}-${var.environment}-bq-destination"


### PR DESCRIPTION
## Context
When using the `incremental_deduped_history` sync mode, Airbyte needs full access to read all the data in BQ as part of its dedup. We don't want to give non-production environments access to read hidden fields, since that would give them access to hidden production data as well.

## Changes proposed in this pull request
Adds a `skip-policy-tags` variable, defaulted to `false`, and passes it along to the .NET deployment task.
The corresponding PR for the analytics library is at https://github.com/DFE-Digital/dfe-analytics-dotnet/pull/65

## Guidance to review
This is tested in a branch of TRS on the dev environment.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
