### PR TITLE
Add datacatalog.viewer to taxonomy for airbyte

### DIFF
--- a/aks/airbyte/gcp.tf
+++ b/aks/airbyte/gcp.tf
@@ -106,3 +106,11 @@ resource "google_bigquery_dataset_iam_member" "bqowner" {
   role       = "roles/bigquery.dataOwner"
   member     = "serviceAccount:${data.google_service_account.bqappender[0].email}"
 }
+
+resource "google_data_catalog_taxonomy_iam_member" "bqownerdc" {
+  count = var.gcp_bq_sa == null ? 0 : 1
+
+  taxonomy = "projects/${data.google_project.main.project_id}/locations/${local.gcp_region}/taxonomies/${var.gcp_taxonomy_id}"
+  role     = "roles/datacatalog.viewer"
+  member   = "serviceAccount:${data.google_service_account.bqappender[0].email}"
+}

--- a/aks/airbyte/tfdocs.md
+++ b/aks/airbyte/tfdocs.md
@@ -34,6 +34,7 @@
 | [google_bigquery_dataset_iam_member.bqowner](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_bigquery_dataset_iam_member.owner](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_bigquery_dataset_iam_member.owner_internal](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
+| [google_data_catalog_taxonomy_iam_member.bqownerdc](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/data_catalog_taxonomy_iam_member) | resource |
 | [google_project_iam_member.appender](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.bqappender](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.viewer](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |


### PR DESCRIPTION
## Context
For airbyte, the BQ service account needs permissions on the taxonomy

## Changes proposed in this pull request
Add roles/datacatalog.viewer to the service account in the airbyte terraform module

## Guidance to review
deploy-plan from an existing airbyte service to this branch, output from my test below

Terraform will perform the following actions:

  module.airbyte[0].google_data_catalog_taxonomy_iam_member.bqownerdc[0] will be created
  + resource "google_data_catalog_taxonomy_iam_member" "bqownerdc" {
      + etag     = (known after apply)
      + id       = (known after apply)
      + member   = "serviceAccount:someservice-bigquery-qa@some-project.iam.gserviceaccount.com"
      + project  = (known after apply)
      + region   = (known after apply)
      + role     = "roles/datacatalog.viewer"
      + taxonomy = "projects/someproject/0/locations/europe-west2/taxonomies/666666666666666"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Also deployed a review app in rtt using this branch (rm1) which worked successfully

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
