### PR TITLE
Backout previous Airbyte modue change

### DIFF
--- a/aks/airbyte/gcp.tf
+++ b/aks/airbyte/gcp.tf
@@ -107,10 +107,10 @@ resource "google_bigquery_dataset_iam_member" "bqowner" {
   member     = "serviceAccount:${data.google_service_account.bqappender[0].email}"
 }
 
-resource "google_data_catalog_taxonomy_iam_member" "bqownerdc" {
-  count = var.gcp_bq_sa == null ? 0 : 1
+# resource "google_data_catalog_taxonomy_iam_member" "bqownerdc" {
+#   count = var.gcp_bq_sa == null ? 0 : 1
 
-  taxonomy = "projects/${data.google_project.main.project_id}/locations/${local.gcp_region}/taxonomies/${var.gcp_taxonomy_id}"
-  role     = "roles/datacatalog.viewer"
-  member   = "serviceAccount:${data.google_service_account.bqappender[0].email}"
-}
+#   taxonomy = "projects/${data.google_project.main.project_id}/locations/${local.gcp_region}/taxonomies/${var.gcp_taxonomy_id}"
+#   role     = "roles/datacatalog.viewer"
+#   member   = "serviceAccount:${data.google_service_account.bqappender[0].email}"
+# }

--- a/aks/airbyte/tfdocs.md
+++ b/aks/airbyte/tfdocs.md
@@ -34,7 +34,6 @@
 | [google_bigquery_dataset_iam_member.bqowner](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_bigquery_dataset_iam_member.owner](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
 | [google_bigquery_dataset_iam_member.owner_internal](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/bigquery_dataset_iam_member) | resource |
-| [google_data_catalog_taxonomy_iam_member.bqownerdc](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/data_catalog_taxonomy_iam_member) | resource |
 | [google_project_iam_member.appender](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.bqappender](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.viewer](https://registry.terraform.io/providers/hashicorp/google/6.6.0/docs/resources/project_iam_member) | resource |


### PR DESCRIPTION

## Context
Back out previous commit

- Comment out Add datacatalog.viewer to taxonomy for airbyte
- causes Error 403: The caller does not have permission from gh workflow

## Changes proposed in this pull request
remove permission resource that was just added

## Guidance to review
tested from service branch

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
