### PR TITLE
Enable private link \ endpoints for backup storage account

### DIFF
--- a/aks/postgres/data.tf
+++ b/aks/postgres/data.tf
@@ -37,3 +37,23 @@ data "azurerm_monitor_diagnostic_categories" "main" {
 
   resource_id = azurerm_postgresql_flexible_server.main[0].id
 }
+
+#Blob Private networking
+data "azurerm_virtual_network" "priv" {
+  count               = local.azure_enable_backup_storage && var.azure_backup_storage_private_endpoint_enabled ? 1 : 0
+  name                = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_subnet" "priv" {
+  count                = local.azure_enable_backup_storage && var.azure_backup_storage_private_endpoint_enabled ? 1 : 0
+  name                 = "private-storage-snet"
+  virtual_network_name = "${var.cluster_configuration_map.resource_prefix}-vnet"
+  resource_group_name  = var.cluster_configuration_map.resource_group_name
+}
+
+data "azurerm_private_dns_zone" "priv" {
+  count               = local.azure_enable_backup_storage && var.azure_backup_storage_private_endpoint_enabled ? 1 : 0
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = "${var.cluster_configuration_map.resource_prefix}-bs-rg"
+}

--- a/aks/postgres/resources.tf
+++ b/aks/postgres/resources.tf
@@ -139,6 +139,7 @@ resource "azurerm_storage_account" "backup" {
   account_replication_type         = "GRS"
   allow_nested_items_to_be_public  = false
   cross_tenant_replication_enabled = false
+  public_network_access_enabled    = var.azure_backup_storage_public_network_access_enabled
 
   blob_properties {
     delete_retention_policy {
@@ -151,6 +152,34 @@ resource "azurerm_storage_account" "backup" {
   }
 
   lifecycle { ignore_changes = [tags] }
+}
+
+resource "azurerm_private_endpoint" "storage" {
+  count = local.azure_enable_backup_storage && var.azure_backup_storage_private_endpoint_enabled ? 1 : 0
+
+  name                = "${azurerm_storage_account.backup[0].name}-pe"
+  location            = data.azurerm_resource_group.main[0].location
+  resource_group_name = data.azurerm_resource_group.main[0].name
+  subnet_id           = data.azurerm_subnet.priv[0].id
+
+  private_dns_zone_group {
+    name                 = data.azurerm_private_dns_zone.priv[0].name
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.priv[0].id]
+  }
+
+  private_service_connection {
+    name                           = "${azurerm_storage_account.backup[0].name}-pe"
+    private_connection_resource_id = azurerm_storage_account.backup[0].id
+    subresource_names              = ["blob"]
+    is_manual_connection           = false
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags
+    ]
+  }
+
 }
 
 resource "azurerm_storage_management_policy" "backup" {

--- a/aks/postgres/tfdocs.md
+++ b/aks/postgres/tfdocs.md
@@ -35,6 +35,7 @@ No modules.
 | [azurerm_postgresql_flexible_server_configuration.sync_replication_slots](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_configuration.wal_level](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_configuration) | resource |
 | [azurerm_postgresql_flexible_server_database.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/postgresql_flexible_server_database) | resource |
+| [azurerm_private_endpoint.storage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_storage_account.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
 | [azurerm_storage_container.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container_immutability_policy.backup](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container_immutability_policy) | resource |
@@ -46,9 +47,12 @@ No modules.
 | [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_diagnostic_categories.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_diagnostic_categories) | data source |
 | [azurerm_private_dns_zone.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
+| [azurerm_private_dns_zone.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/private_dns_zone) | data source |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.monitoring](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subnet.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_virtual_network.priv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
 
 ## Inputs
 
@@ -57,6 +61,8 @@ No modules.
 | <a name="input_admin_password"></a> [admin\_password](#input\_admin\_password) | Password of the admin user | `string` | `null` | no |
 | <a name="input_admin_username"></a> [admin\_username](#input\_admin\_username) | Username of the admin user | `string` | `null` | no |
 | <a name="input_alert_window_size"></a> [alert\_window\_size](#input\_alert\_window\_size) | The period of time that is used to monitor alert activity e.g. PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H. The interval between checks is adjusted accordingly. | `string` | `"PT5M"` | no |
+| <a name="input_azure_backup_storage_private_endpoint_enabled"></a> [azure\_backup\_storage\_private\_endpoint\_enabled](#input\_azure\_backup\_storage\_private\_endpoint\_enabled) | Use a private endpoint for backup storage account access | `bool` | `false` | no |
+| <a name="input_azure_backup_storage_public_network_access_enabled"></a> [azure\_backup\_storage\_public\_network\_access\_enabled](#input\_azure\_backup\_storage\_public\_network\_access\_enabled) | Whether public network access is allowed for the storage account | `bool` | `true` | no |
 | <a name="input_azure_cpu_threshold"></a> [azure\_cpu\_threshold](#input\_azure\_cpu\_threshold) | n/a | `number` | `80` | no |
 | <a name="input_azure_enable_backup_storage"></a> [azure\_enable\_backup\_storage](#input\_azure\_enable\_backup\_storage) | n/a | `bool` | `true` | no |
 | <a name="input_azure_enable_high_availability"></a> [azure\_enable\_high\_availability](#input\_azure\_enable\_high\_availability) | n/a | `bool` | `false` | no |

--- a/aks/postgres/variables.tf
+++ b/aks/postgres/variables.tf
@@ -203,3 +203,15 @@ locals {
   server_docker_image = var.server_docker_image == null ? "${var.server_docker_repo}:postgres-${var.server_version}-alpine" : var.server_docker_image
   command             = var.use_airbyte ? ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=2", "-c", "max_replication_slots=1", "-c", "max_slot_wal_keep_size=2048"] : null
 }
+
+variable "azure_backup_storage_private_endpoint_enabled" {
+  type        = bool
+  default     = false
+  description = "Use a private endpoint for backup storage account access"
+}
+
+variable "azure_backup_storage_public_network_access_enabled" {
+  type        = bool
+  description = "Whether public network access is allowed for the storage account"
+  default     = true
+}


### PR DESCRIPTION
## Context
This change enables the optional use of private endpoints for backup storage accounts, removing the need for storage accounts to be publicly accessible in combination with changes below that enable use of AKS pods to handle Postgres backup\restores.

Related PRs (but not direct pre-reqs):
https://github.com/DFE-Digital/teacher-services-cloud/pull/655
https://github.com/DFE-Digital/apply-for-teacher-training/pull/12164

**This change does NOT enforce use of the private networking on the storage account, this is to follow.**

**This change does NOT provide any means of using the storage account via the private endpoint, this is handled per service in the related PRs.**

## Changes proposed in this pull request
- Add lookups for networking components created as part of AKS cluster setup
- Add variable `azure_backup_storage_private_endpoint_enabled` to allow use of private endpoint, defaults to false
- Create private endpoint for backup storage account when `azure_backup_storage_private_endpoint_enabled` enabled
- Add variable `azure_backup_storage_public_network_access_enabled` to disable use of public networking, default of true to retain the previous implicit default of allowing public networking.
- Disable public access to backup storage account when `azure_backup_storage_public_network_access_enabled` set to false.

## Guidance to review
Key is this has no effect on existing services until this is explicirtly implemented, and even then 
### Test for no changes (ie existing infra stays as is until explicitly modified)
Where `azure_backup_storage_private_endpoint_enabled` is set to false.
For any service and environment where module postgres has `azure_enable_backup_storage=true` (typically production) and `azure_backup_storage_private_endpoint_enabled=false` (ie this new feature hasn't been enabled), run a plan to ensure there are no changes.

### Test for changes (ie introducing this feature to a service)
This applies for any service, att will be used as an example as it is planned to be implemented here initially.
Checkout branch `2911-enable-privatelink-staging` (this has pre-set the target for terraform-modules `TERRAFORM_MODULES_TAG=2911-backup-sa-private-link`).
run:
`make staging terraform-plan`
only change (ignoring image related) should be adding a new private endpoint.
```
 # module.postgres.azurerm_private_endpoint.storage[0] will be created
  + resource "azurerm_private_endpoint" "storage" {
      + custom_dns_configs       = (known after apply)
      + id                       = (known after apply)
      + location                 = "uksouth"
      + name                     = "s189t01attdbbkpstgsa-pe"
      + network_interface        = (known after apply)
      + private_dns_zone_configs = (known after apply)
      + resource_group_name      = "s189t01-att-stg-rg"
      + subnet_id                = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-ts-rg/providers/Microsoft.Network/virtualNetworks/s189t01-tsc-test-vnet/subnets/private-storage-snet"

      + private_dns_zone_group {
          + id                   = (known after apply)
          + name                 = "privatelink.blob.core.windows.net"
          + private_dns_zone_ids = [
              + "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-tsc-test-bs-rg/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net",
            ]
        }

      + private_service_connection {
          + is_manual_connection           = false
          + name                           = "s189t01attdbbkpstgsa-pe"
          + private_connection_resource_id = "/subscriptions/20da9d12-7ee1-42bb-b969-3fe9112964a7/resourceGroups/s189t01-att-stg-rg/providers/Microsoft.Storage/storageAccounts/s189t01attdbbkpstgsa"
          + private_ip_address             = (known after apply)
          + subresource_names              = [
              + "blob",
            ]
        }
    }

```
### Test for no changes on other environments
`make qa terraform-plan`
`make production terraform-plan CONFIRM_PRODUCTION=yes`

No changes should be shown.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
