### PR TITLE
Shorten the airbyte db init job name

### DIFF
--- a/aks/airbyte/resources.tf
+++ b/aks/airbyte/resources.tf
@@ -151,7 +151,7 @@ resource "kubernetes_job" "airbyte-database-setup" {
   depends_on = [kubernetes_secret.airbyte-sql, time_sleep.wait_15_seconds]
 
   metadata {
-    name      = "${var.service_name}-${var.environment}-ab-db-init-${kubernetes_secret.airbyte-sql.metadata[0].name}"
+    name      = "${var.service_short}-${var.environment}-ab-db-init-${kubernetes_secret.airbyte-sql.metadata[0].name}"
     namespace = var.namespace
   }
 


### PR DESCRIPTION

## Context
Shorten the airbyte db init job name

- use service_short instead of service_name
- otherwise it can exceed length limits

e.g. Error: Failed to create Job! API error: Job.batch "itt-mentor-services-pr-1962-ab-db-init-ittmspr-1962absql7cd40ezzzzz" is invalid: [metadata.labels: Invalid value: "itt-mentor-services-pr-1962-ab-db-init-ittmspr-1962absql7cd40ezzzzz": must be no more than 63 bytes, spec.template.labels: Invalid value: "itt-mentor-services-pr-1962-ab-db-init-ittmspr-1962absql7cd40ezzzzz": must be no more than 63 bytes] 

## Changes proposed in this pull request
Update variable used in terraform module 

## Guidance to review
Can run from another service
I pointed the same ittms create as above using the branch and now get
# module.airbyte[0].kubernetes_job.airbyte-database-setup will be created
  + resource "kubernetes_job" "airbyte-database-setup" {

## Checklist

- [ ] I have performed a self-review of my code, including formatting and typos
- [ ] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [ ] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
