### PR TITLE
correct checkout version reference for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: actions/checkout@7
+      - uses: actions/checkout@v7
         with: {ref: "${{ github.event.release.tag_name }}"}
       - uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67
         with: {ref: stable}
@@ -23,7 +23,7 @@ jobs:
     name: Update testing tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@7
+      - uses: actions/checkout@v7
         with: {ref: "${{ github.event.release.tag_name }}"}
       - uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67
         with: {ref: testing}


### PR DESCRIPTION
## Context
Release workflow is currently failing with:
```
Error: Command failed: git -C /home/runner/work/terraform-modules/terraform-modules push --force origin stable
remote: Permission to DFE-Digital/terraform-modules.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/DFE-Digital/terraform-modules/': The requested URL returned error: 403
```
From testing, this appears to be due to the version reference in the checkout action missing the v.

Testing using a tag `testingupdatetag` and setting to select commit SHAs off a branch works, only fails when the v is removed but this is with a different and expected error complaining about the action reference. Its unclear why the standard release workflow fails as it does, from the logs of the failed run we can see that v3 is used, not the intended v7, possibly its related to this and the way git is setup from it.

## Changes proposed in this pull request
- Add `v` to checkout action reference.

## Guidance to review
See working tag update (for `testingupdatetag`): https://github.com/DFE-Digital/terraform-modules/actions/runs/32238522152
See failed tag update for test branch  (for `testingupdatetag`): https://github.com/DFE-Digital/terraform-modules/actions/runs/32234471118

## After merging
Edit release v0.76.0 which should trigger release workflow and tag this as stable.

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [ ] I have attached the pull request to the trello card
