### PR TITLE
add a manual tag update workflow for module release

### DIFF
--- a/.github/workflows/manual-release-tag.yaml
+++ b/.github/workflows/manual-release-tag.yaml
@@ -1,0 +1,42 @@
+---
+name: Manually Set Release Tags
+
+on:
+  workflow_dispatch:
+    inputs:
+      stable_sha:
+        description: Full SHA to point the stable tag at
+        required: true
+        type: string
+      testing_sha:
+        description: Full SHA to point the stable tag at
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  update-stable-tag:
+    name: Update stable tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: "${{ inputs.stable_sha }}"
+
+      - uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67
+        with:
+          ref: "stable"
+
+  update-testing-tag:
+    name: Update testing tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: "${{ inputs.testing_sha }}"
+
+      - uses: EndBug/latest-tag@8fcae8848c1e23fd8212258f69a9619bc62cad67
+        with:
+          ref: "testing"


### PR DESCRIPTION
## Context

Current Release workflow is failing for undetermined reasons so stable and testing tags are not being updated. This adds a manually triggered workflow that updates the stable and testing tags to supplied SHAs.

## Changes proposed in this pull request
- New workflow to manually run and set desired tags

## Guidance to review
Sense check changes, see simplified [workflow ](https://github.com/DFE-Digital/terraform-modules/actions/runs/32248083115) run which sets testing tags [testingtagtesting ](https://github.com/DFE-Digital/terraform-modules/releases/tag/testingtagtesting) and [testingtagstable](https://github.com/DFE-Digital/terraform-modules/releases/tag/testingtagstable)

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
