### PR TITLE
2969 - failover set to true for pg slot rep

### DIFF
--- a/aks/airbyte/files/airbyte.sql.tmpl
+++ b/aks/airbyte/files/airbyte.sql.tmpl
@@ -25,7 +25,11 @@ SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = 'airbyte_slot
  \echo 'Replication slot "airbyte_slot" already exists.'
 \else
  ALTER ROLE CURRENT_USER WITH REPLICATION;
- SELECT * FROM pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
+ SELECT * FROM pg_create_logical_replication_slot(
+    slot_name => 'airbyte_slot',
+    plugin    => 'pgoutput',
+    failover  => true
+);
  ALTER ROLE CURRENT_USER WITH NOREPLICATION;
 \endif
 \set publication_exists false


### PR DESCRIPTION
## Context

During Postgres maintenance the connections can be dropped between Postgres and Airbyte. The replication slot is then dropped and will only be reinstated when the fix-replication-slot workflow runs. This change is intended to avoid the replication slot being dropped.

## Changes proposed in this pull request

Replication slot creation changed
From
SELECT * FROM pg_create_logical_replication_slot('airbyte_slot', 'pgoutput');
to
SELECT * FROM pg_create_logical_replication_slot(
    slot_name => 'airbyte_slot',
    plugin    => 'pgoutput',
    failover  => true
);

## Guidance to review

The new SQL was tested manually on trs dev, s189t01-trs-dev-airbyte-conn, s189t01-trs-dv-pg. 

## Checklist

- [x] I have performed a self-review of my code, including formatting and typos
- [x] I have [cleaned the commit history](https://www.annashipman.co.uk/jfdi/good-pull-requests.html)
- [x] I have added the `Devops` label
- [x] I have attached the pull request to the trello card
